### PR TITLE
Fixed map area

### DIFF
--- a/src/components/PlayerStats.vue
+++ b/src/components/PlayerStats.vue
@@ -53,6 +53,8 @@ function getExpPercentage () {
   padding-bottom: 10px;
   padding-left: 10px;
   padding-right: 10px;
+  height: 70vh;
+  overflow-y: scroll;
   .name-row {
     margin-top: 10px;
     display: flex;


### PR DESCRIPTION
Thought maybe it's a good idea to have the map area fixed, indifferent of what there is open already from the `player stats`. That way the map area will always be visible, and only the `player stats` are scrollable.

PS: I'm not sure if you accept contributions this way, or if you accept contributions at all. But this is a small little fix anyways, I just love your work with the web interface. 

**Before**
![Before](https://user-images.githubusercontent.com/11844042/191623213-5c31b56e-1906-42c4-8bf2-90ea060a21cc.gif)

**After**
![after](https://user-images.githubusercontent.com/11844042/191623240-602a5312-bcbe-4fa3-855e-00ad5f904acb.gif)
