### PR TITLE
Save options in local storage

### DIFF
--- a/src/components/KeyboardInput.vue
+++ b/src/components/KeyboardInput.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 
 import { NButton, NIcon } from 'naive-ui'
 
@@ -145,6 +145,8 @@ onKeydown((ev) => {
     state.showHelp = true
   }
 })
+
+watch(state.options, () => localStorage.setItem('options', JSON.stringify(state.options)))
 
 </script>
 

--- a/src/components/OptionsMenu.vue
+++ b/src/components/OptionsMenu.vue
@@ -47,6 +47,9 @@
 import { NSwitch, NButton } from 'naive-ui'
 
 import { state } from '@/composables/state'
+import { watch } from 'vue';
+
+watch(state.options, () => localStorage.setItem('options', JSON.stringify(state.options)))
 
 function goFullscreen () {
   let app = document.getElementById('app')

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -78,6 +78,12 @@ function openCloseSider () {
   triggerResize()
 }
 
+const options = JSON.parse(localStorage.getItem('options'))
+
+if (options !== null) {
+  state.options = options
+}
+
 </script>
 
 <style lang="less">

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -78,10 +78,14 @@ function openCloseSider () {
   triggerResize()
 }
 
-const options = JSON.parse(localStorage.getItem('options'))
-
-if (options !== null) {
-  state.options = options
+try {
+  const options = JSON.parse(localStorage.getItem('options'))
+  if (options !== null) {
+    state.options = options
+  }
+} catch (err) {
+  console.log(err)
+  localStorage.setItem('options', '')
 }
 
 </script>


### PR DESCRIPTION
This PR will have options saving in `localStorage`. Upon reload of the page, all settings will be the same as set.