### PR TITLE
Tweaks to fixed-map and PlayerStats visual separation

### DIFF
--- a/src/components/PlayerStats.vue
+++ b/src/components/PlayerStats.vue
@@ -64,7 +64,6 @@ function getPlayerStatsClass () {
   padding-right: 10px;
 
   &.fixed-map {
-    height: 70vh;
     overflow-y: scroll;
   }
 

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -99,6 +99,9 @@ try {
     flex-direction: column;
     justify-content: space-between;
     height: 100%;
+    .bottom-area {
+      border-top: 1px solid rgba(255, 255, 255, 0.09);
+    }
     .map-area {
       align-items: center;
       display: flex;


### PR DESCRIPTION
Best to show rather than tell, so here's the current view. You can see that the PlayerStats ends abruptly before the bottom-area begins.

![image](https://user-images.githubusercontent.com/398357/192324392-2629f197-b624-4bfc-b878-fb42e0951776.png)

After the addition of a top border to the bottom-area and removing the `height: 70vh;` from PlayerStats:

![image](https://user-images.githubusercontent.com/398357/192324638-6f8fe65f-8837-49a1-94a5-bd38815f1d5b.png)
