### PR TITLE
Update inventory with actions

### DIFF
--- a/src/components/InventoryRow.vue
+++ b/src/components/InventoryRow.vue
@@ -1,12 +1,74 @@
 <template>
-  <div>
-    <div v-html="props.amount + 'x ' + ansiSpan(props.colorName)"></div>
+  <div class="inventory-item">
+    <div v-on:click="toggle()"
+         v-html="chevron() + props.amount + 'x ' + ansiSpan(props.colorName)"
+         class="item-name"></div>
+    <div v-if="!hidden" class="actions">
+      <n-button v-for="action in actions"
+                :disabled="action === 'drink' && isDrinkDisabled"
+                @click="cmd(`${action} ${props.name}`) && toggle()"
+                :key="action"
+                class="action">
+        {{action}}
+      </n-button>
+    </div>
   </div>
 </template>
 
 <script setup>
-import { defineProps } from "vue";
+import { defineProps, defineEmits, ref, watch, reactive } from 'vue';
 import { ansiSpan } from 'ansi-to-span'
+import { NButton } from 'naive-ui'
+import { useWebSocket } from '@/composables/web_socket';
+import { helpers } from '@/composables/helpers'
+import {state} from "@/composables/state";
 
-const props = defineProps(['colorName', 'amount'])
+const props = defineProps(['iid', 'colorName', 'amount', 'name', 'type', 'subtype', 'expanded', 'toggleExpand'])
+const { getActions } = helpers()
+const hidden = ref(!props.expanded)
+const { cmd } = useWebSocket()
+const emit = defineEmits(['toggled'])
+
+function toggle() {
+  hidden.value = !hidden.value
+  emit('toggled', props.iid)
+}
+
+function chevron() {
+  return hidden.value ? '- ' : '| '
+}
+
+let actions = reactive(getActions({
+  name: props.name,
+  type: props.type,
+  subtype: props.subtype
+}))
+
+const isDrinkDisabled = ref(false)
+watch(()=> state.gameState.affects, () => {
+  isDrinkDisabled.value = !!(props.type === 'consumable' &&
+      props.subtype === 'potion' &&
+      state.gameState.affects.find(af => af.name === props.name));
+})
 </script>
+
+<style scoped lang="less">
+  .inventory-item {
+    padding-bottom: 5px;
+    .item-name {
+      cursor: pointer;
+    }
+  }
+
+  .actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    .action {
+      margin-right: 50px;
+      margin-bottom: 5px;
+      margin-top: 5px;
+      text-transform: capitalize;
+    }
+  }
+
+</style>

--- a/src/composables/constants/action_mapper.js
+++ b/src/composables/constants/action_mapper.js
@@ -1,0 +1,64 @@
+import { state } from '@/composables/state'
+console.log(state.gameState.room)
+console.log(state.gameState.affects);
+export const action_mapper = [
+    // TODO
+    // We need room.flags to be implemented
+    /*{
+        action: 'sell',
+        condition: () => state.gameState.room.flags.includes('store')
+    },*/
+    // Slot would be nice to implement with a modal
+    /*{
+        action: 'slot',
+        condition: (it) => (it.type === 'consumable' && ['potion', 'food', 'fragment'].includes(it.subtype)) || it.type === 'scroll'
+    },*/
+    {
+        action: 'look',
+        condition: () => true
+    },
+    {
+        action: 'examine',
+        condition: () => true
+    },
+    {
+        action: 'drink',
+        condition: (it) => it.type === 'consumable' && it.subtype === 'potion'
+    },
+    {
+        action: 'eat',
+        condition: (it) => it.type === 'consumable' && ['food', 'mote', 'fragment'].includes(it.subtype)
+    },
+    {
+        action: 'read',
+        condition: (it) => it.type === 'book' || it.type === 'scroll'
+    },
+    {
+        action: 'wield',
+        condition: (it) => it.type === 'weapon'
+    },
+    {
+        action: 'wear',
+        condition: (it) => it.type === 'armor'
+    },
+    {
+        action: 'filet',
+        condition: (it) => it.type === 'material' && it.subtype === 'fish'
+    },
+    {
+        action: 'tan',
+        condition: (it) => it.type === 'material' && it.subtype === 'hide'
+    },
+    {
+        action: 'plant',
+        condition: (it) => it.type === 'material' && it.subtype === 'seed'
+    },
+    {
+        action: 'wrap',
+        condition: (it) => it.type === 'material' && it.subtype === 'bandage'
+    },
+    {
+        action: 'drop',
+        condition: () => true
+    }
+]

--- a/src/composables/constants/action_mapper.js
+++ b/src/composables/constants/action_mapper.js
@@ -30,6 +30,10 @@ export const action_mapper = [
         condition: (it) => it.type === 'consumable' && ['food', 'mote', 'fragment'].includes(it.subtype)
     },
     {
+        action: 'deploy',
+        condition: (it) => it.subtype ==='deployable'
+    },
+    {
         action: 'read',
         condition: (it) => it.type === 'book' || it.type === 'scroll'
     },

--- a/src/composables/helpers.js
+++ b/src/composables/helpers.js
@@ -1,3 +1,5 @@
+import { action_mapper } from '@/composables/constants/action_mapper';
+
 export function helpers() {
     function copperToMoneyString(amount) {
         let valueString = '';
@@ -22,5 +24,16 @@ export function helpers() {
         return valueString;
     }
 
-    return { copperToMoneyString }
+    function getActions(item) {
+        const actions = []
+        action_mapper.map(action => {
+            if (action.condition(item)) {
+                actions.push(action.action)
+            }
+        })
+
+        return actions;
+    }
+
+    return { copperToMoneyString, getActions }
 }


### PR DESCRIPTION
Added actions feature to the inventory. I have increased the padding between inventory items.
We have to see if the text is too small for mobile users to tap on each line individually. I played around with it on my IPhone SE (2022) and it felt mostly fine, and that phone is tiny by modern standards. Action buttons should be good for size. Only thing missing is the ability to `Sell` an item when in a room with a shop, looks like we  need a flag from the back end in the rooms. 

The logic withing the Inventory components can be improved upon I think. There's a bit of ping-pong playing between components. I wanted for the actions drop down to not close when drinking or eating an item if you have multiples of that item in the inventory.

Play around with it and tell me what you think, what we should change. 

![image](https://user-images.githubusercontent.com/11844042/192472131-7674f7c6-37f1-475e-8963-46e6c81dd642.png)

PS: If you happen to have a look at the empty glass bottles in my inventory in the screenshot, I swear that my character just likes the taste of healing potions, he's not an addict :smile: 