### PR TITLE
Add inventory and equipment modals

### DIFF
--- a/src/components/BattleStatus.vue
+++ b/src/components/BattleStatus.vue
@@ -6,9 +6,9 @@
           <n-progress type="circle" status="error" :percentage="entity.nextAction / 20 * 100" :show-indicator="false"></n-progress>
         </div>
         <div class="vitals" v-if="entity.hp > 0">
-          <n-progress type="line" status="success" :percentage="entity.hp" :show-indicator="false"></n-progress>
-          <n-progress type="line" status="default" :percentage="entity.en" :show-indicator="false"></n-progress>
-          <n-progress type="line" status="warning" :percentage="entity.st" :show-indicator="false"></n-progress>
+          <n-progress type="line" status="success" aria-label="Health" :percentage="entity.hp" :show-indicator="false"></n-progress>
+          <n-progress type="line" status="default" aria-label="Energy" :percentage="entity.en" :show-indicator="false"></n-progress>
+          <n-progress type="line" status="warning" aria-label="Stamina" :percentage="entity.st" :show-indicator="false"></n-progress>
         </div>
         <div class="vitals bold-red" v-if="entity.hp == 0">DEAD</div>
         <div class="name-container">
@@ -33,9 +33,9 @@
           <div v-if="!entity.target" class="targeting">No target</div>
         </div>
         <div class="vitals" v-if="entity.hp > 0">
-          <n-progress type="line" status="success" :percentage="entity.hp" :show-indicator="false"></n-progress>
-          <n-progress type="line" status="default" :percentage="entity.en" :show-indicator="false"></n-progress>
-          <n-progress type="line" status="warning" :percentage="entity.st" :show-indicator="false"></n-progress>
+          <n-progress type="line" status="success" aria-label="Enemy Health" :percentage="entity.hp" :show-indicator="false"></n-progress>
+          <n-progress type="line" status="default" aria-label="Enemy Energy" :percentage="entity.en" :show-indicator="false"></n-progress>
+          <n-progress type="line" status="warning" aria-label="Enemy Stamina" :percentage="entity.st" :show-indicator="false"></n-progress>
         </div>
         <div class="vitals bold-red" v-if="entity.hp == 0">DEAD</div>
         <div class="action">

--- a/src/components/EquipmentCollapse.vue
+++ b/src/components/EquipmentCollapse.vue
@@ -1,13 +1,13 @@
 <template>
   <n-collapse-item title="Equipment">
-    <EquipmentRow v-for="(item, index) in equipment" :key="index" v-bind="item"></EquipmentRow>
+    <EquipmentRow v-for="(item, index) in equipment" :key="index" v-bind="item" v-on:click="clickHandler(item)"></EquipmentRow>
   </n-collapse-item>
 </template>
 
 <script setup>
 import { state } from '@/composables/state';
 import { useWebSocket } from '@/composables/web_socket';
-import { watch, reactive } from "vue";
+import { watch, reactive } from 'vue';
 import { NCollapseItem } from 'naive-ui'
 import EquipmentRow from '@/components/EquipmentRow.vue'
 
@@ -33,5 +33,11 @@ function setEquipment(equipmentIIDs) {
       level: false
     }
   })
+}
+
+function clickHandler(item) {
+  state.modal.visible = true
+  state.modal.item = item
+  state.modal.menu = 'equipment'
 }
 </script>

--- a/src/components/EquipmentRow.vue
+++ b/src/components/EquipmentRow.vue
@@ -2,16 +2,13 @@
   <div class="equipment-row" :class="{'border-top' : isHead}">
     <div class="slot"> {{props.slot ? props.slot : props.type}}: </div>
     <div><span v-if="props.level">[{{props.level}}] </span><span class="equipment-item" v-html="ansiSpan(props.colorName)"></span></div>
-    <div class="remove" v-if="props.name" v-on:click="cmd(`remove ${props.name}`)">X</div>
   </div>
 </template>
 
 <script setup>
 import { defineProps } from 'vue'
 import { ansiSpan } from 'ansi-to-span'
-import { useWebSocket } from '@/composables/web_socket';
 
-const { cmd } = useWebSocket()
 const props = defineProps(['name', 'colorName', 'slot', 'type', 'level'])
 const isHead =  props.slot !== 'head'
 </script>
@@ -19,10 +16,11 @@ const isHead =  props.slot !== 'head'
 <style scoped lang="less">
 .equipment-row {
   display: grid;
-  grid-template-columns: 1.5fr 3fr 0.2fr;
+  grid-template-columns: 1.5fr 3fr;
   gap: 1em;
   padding-top: 5px;
   padding-bottom: 5px;
+  cursor: pointer;
 
   .slot {
     text-transform: capitalize;

--- a/src/components/InventoryCollapse.vue
+++ b/src/components/InventoryCollapse.vue
@@ -84,7 +84,7 @@ function clickHandler(item) {
   state.modal.menu = 'inventory'
 
   const commandCacheKey = command_ids.EXAMINE + item.iid.toString()
-  cmd(`examine ${item.name}`, commandCacheKey)
+  cmd(`examine iid:${item.iid}`, commandCacheKey)
 }
 
 // Setters

--- a/src/components/InventoryRow.vue
+++ b/src/components/InventoryRow.vue
@@ -1,56 +1,14 @@
 <template>
   <div class="inventory-item">
-    <div v-on:click="toggle()"
-         v-html="chevron() + props.amount + 'x ' + ansiSpan(props.colorName)"
-         class="item-name"></div>
-    <div v-if="!hidden" class="actions">
-      <n-button v-for="action in actions"
-                size="medium"
-                :disabled="action === 'drink' && isDrinkDisabled"
-                @click="cmd(`${action} ${props.name}`, '1234') && toggle()"
-                :key="action"
-                class="action">
-        {{action}}
-      </n-button>
-    </div>
+    <div v-html="props.amount + 'x ' + ansiSpan(props.colorName)" class="item-name"></div>
   </div>
 </template>
 
 <script setup>
-import { defineProps, defineEmits, ref, watch, reactive } from 'vue'
+import { defineProps } from 'vue'
 import { ansiSpan } from 'ansi-to-span'
-import { NButton } from 'naive-ui'
-import { useWebSocket } from '@/composables/web_socket'
-import { helpers } from '@/composables/helpers'
-import { state } from '@/composables/state'
 
-const props = defineProps(['iid', 'colorName', 'amount', 'name', 'type', 'subtype', 'expanded', 'toggleExpand'])
-const { getActions } = helpers()
-const hidden = ref(!props.expanded)
-const { cmd } = useWebSocket()
-const emit = defineEmits(['toggled'])
-
-function toggle() {
-  hidden.value = !hidden.value
-  emit('toggled', props.iid)
-}
-
-function chevron() {
-  return hidden.value ? '- ' : '| '
-}
-
-let actions = reactive(getActions({
-  name: props.name,
-  type: props.type,
-  subtype: props.subtype
-}))
-
-const isDrinkDisabled = ref(false)
-watch(()=> state.gameState.affects, () => {
-  isDrinkDisabled.value = !!(props.type === 'consumable' &&
-      props.subtype === 'potion' &&
-      state.gameState.affects.find(af => af.name === props.name));
-})
+const props = defineProps(['colorName', 'amount'])
 </script>
 
 <style scoped lang="less">

--- a/src/components/ModalCard.vue
+++ b/src/components/ModalCard.vue
@@ -1,0 +1,201 @@
+<template>
+    <n-card id="item-modal" :class="getSideClass()" v-if="state.modal.visible">
+      <p class="close" v-on:click="closeModal()">x</p>
+      <n-tabs type="line" animated size="large">
+        <n-tab-pane name="actions" tab="Actions">
+          <h3 v-html="item.amount + 'x ' + ansiSpan(item.colorName)"></h3>
+          <div class="actions">
+            <n-button v-for="action in actions"
+                      size="medium"
+                      ghost
+                      :type="getButtonType(action)"
+                      :disabled="action === 'drink' && isDrinkDisabled"
+                      @click="clickedAction(action)"
+                      :key="action"
+                      class="action">
+              <!-- The action.split is a hack to manage fish bait and fish hook while displaying Hook and Bait to the
+              user. There's a better way of doing this, by adding a display attribute to the action objects within
+              action_mapper.js, I will be updating that in a future PR -->
+              {{action.split(" ").length > 1 ? action.split(" ")[1] : action}}
+            </n-button>
+          </div>
+        </n-tab-pane>
+        <n-tab-pane name="look" tab="Look">
+          <div class="item-desc" v-html="ansiSpan(item.description.replaceAll('\n', '<br>'))"></div>
+        </n-tab-pane>
+        <n-tab-pane name="examine" tab="Examine">
+          <div class="examine" v-html="ansiSpan(rawExamine())"></div>
+        </n-tab-pane>
+      </n-tabs>
+    </n-card>
+</template>
+
+<script setup>
+import { NCard, NButton, NTabs, NTabPane } from 'naive-ui'
+import { ref, watch } from 'vue'
+import { ansiSpan } from 'ansi-to-span'
+import { helpers } from '@/composables/helpers'
+import { useWebSocket } from '@/composables/web_socket'
+import { state } from '@/composables/state'
+import { command_ids } from '@/composables/constants/command_ids'
+
+const { getActions } = helpers()
+const { cmd } = useWebSocket()
+
+const isDrinkDisabled = ref(false)
+const item = ref(state.modal.item)
+const actions = ref(getActions({
+  name: item.value.name,
+  type: item.value.type,
+  subtype: item.value.subtype
+}))
+
+// Watchers
+
+watch(() => state.modal.item, () => {
+  if (state.modal.visible) {
+    item.value = state.modal.item
+    const commandCacheKey = command_ids.EXAMINE + item.value.iid.toString()
+    cmd(`examine ${item.value.name}`, commandCacheKey)
+    setActions()
+  }
+})
+
+watch(() => state.modal.menu, () => {
+  state.modal.visible ? setActions() : null
+})
+
+watch(()=> state.gameState.affects, () => {
+  isDrinkDisabled.value = !!(item.value.type === 'consumable' &&
+      item.value.subtype === 'potion' &&
+      state.gameState.affects.find(af => af.name === item.value.name));
+})
+
+// Methods
+
+function closeModal() {
+  state.modal.visible = false
+}
+
+function clickedAction(action) {
+  const nonDestructiveActions = ['look', 'examine', 'compare']
+  if (!nonDestructiveActions.includes(action) && item.value.amount === 1) {
+    closeModal()
+  }
+  cmd(`${action} ${item.value.name}`)
+}
+
+// Setters
+
+function setActions() {
+  if (state.modal.menu === 'inventory') {
+    actions.value = getActions({
+      name: item.value.name,
+      type: item.value.type,
+      subtype: item.value.subtype
+    })
+  }
+
+  if (state.modal.menu === 'equipment') {
+    state.modal.visible ? actions.value = ['remove'] : null
+  }
+}
+
+// Getters
+
+function getSideClass() {
+  return state.options.swapControls ? 'right' : 'left'
+}
+
+function getButtonType(action) {
+  if (action === 'drop' || action === 'remove') {
+    return 'error'
+  }
+}
+
+const rawExamine = function() {
+  const string = state.commandCache[`${command_ids.EXAMINE}${item.value.iid}`]
+  if (string) {
+    return string.replaceAll('\n', '<br>')
+  } else {
+    return "Getting data..."
+  }
+}
+
+</script>
+
+<style scoped lang="less">
+.n-card {
+  position: absolute;
+  margin-top: 200px;
+  width: 400px;
+  z-index: 2;
+}
+
+.left {
+  left: 5px;
+}
+
+.right {
+  right: 5px;
+}
+
+.item-desc {
+  font-size: 1.2em;
+}
+
+h3 {
+  margin-top: 0;
+  font-size: 1.4em;
+}
+
+.close {
+  position: absolute;
+  top: -20px;
+  right: 10px;
+  cursor: pointer;
+  font-size: 1.4em;
+}
+
+.examine {
+  font-size: 1.2em;
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 5px;
+
+  .left {
+    text-align: right;
+  }
+  .right {
+    text-align: left;
+  }
+}
+
+.actions {
+  margin-top: 20px;
+  width: 100%;
+  display: grid;
+  gap: 1em;
+  grid-template-columns: 1fr 1fr 1fr;
+
+  .action {
+    text-transform: capitalize;
+  }
+}
+
+@media screen and (max-width: 1000px) {
+  .n-card {
+    width: 98%;
+    margin-top: 5px;
+    max-height: 95%;
+  }
+
+  .item-desc, .examine {
+    max-height: 68vh;
+    overflow-y: auto;
+  }
+}
+</style>

--- a/src/components/ModalCard.vue
+++ b/src/components/ModalCard.vue
@@ -23,7 +23,7 @@
         <n-tab-pane name="look" tab="Look">
           <div class="item-desc" v-html="ansiSpan(item.description.replaceAll('\n', '<br>'))"></div>
         </n-tab-pane>
-        <n-tab-pane name="examine" tab="Examine" v-if="state.modal.menu === 'inventory'">
+        <n-tab-pane name="examine" tab="Examine">
           <div class="examine" v-html="ansiSpan(rawExamine())"></div>
         </n-tab-pane>
       </n-tabs>
@@ -56,7 +56,7 @@ watch(() => state.modal.item, () => {
   if (state.modal.visible) {
     item.value = state.modal.item
     const commandCacheKey = command_ids.EXAMINE + item.value.iid.toString()
-    cmd(`examine ${item.value.name}`, commandCacheKey)
+    cmd(`examine iid:${item.value.iid}`, commandCacheKey)
     setActions()
   }
 })
@@ -82,7 +82,7 @@ function clickedAction(action) {
   if (!nonDestructiveActions.includes(action) && item.value.amount === 1) {
     closeModal()
   }
-  cmd(`${action} ${item.value.name}`)
+  cmd(`${action} iid:${item.value.iid}`)
 }
 
 // Setters

--- a/src/components/ModalCard.vue
+++ b/src/components/ModalCard.vue
@@ -23,7 +23,7 @@
         <n-tab-pane name="look" tab="Look">
           <div class="item-desc" v-html="ansiSpan(item.description.replaceAll('\n', '<br>'))"></div>
         </n-tab-pane>
-        <n-tab-pane name="examine" tab="Examine">
+        <n-tab-pane name="examine" tab="Examine" v-if="state.modal.menu === 'inventory'">
           <div class="examine" v-html="ansiSpan(rawExamine())"></div>
         </n-tab-pane>
       </n-tabs>

--- a/src/composables/constants/action_mapper.js
+++ b/src/composables/constants/action_mapper.js
@@ -10,14 +10,16 @@ export const action_mapper = [
         action: 'slot',
         condition: (it) => (it.type === 'consumable' && ['potion', 'food', 'fragment'].includes(it.subtype)) || it.type === 'scroll'
     },*/
-    {
-        action: 'look',
-        condition: () => true
-    },
-    {
-        action: 'examine',
-        condition: () => true
-    },
+
+    // Look and Examine are now included in the modal, so buttons not needed for now
+    // {
+    //     action: 'look',
+    //     condition: () => true
+    // },
+    // {
+    //     action: 'examine',
+    //     condition: () => true
+    // },
     {
         action: 'drink',
         condition: (it) => it.type === 'consumable' && it.subtype === 'potion'
@@ -61,6 +63,14 @@ export const action_mapper = [
     {
         action: 'wrap',
         condition: (it) => it.type === 'material' && it.subtype === 'bandage'
+    },
+    {
+        action: 'fish bait',
+        condition: (it) => it.subtype === 'bait'
+    },
+    {
+        action: 'fish hook',
+        condition: (it) => it.subtype === 'hook'
     },
     {
         action: 'drop',

--- a/src/composables/constants/command_ids.js
+++ b/src/composables/constants/command_ids.js
@@ -1,0 +1,3 @@
+export const command_ids = {
+    EXAMINE: '1000'
+}

--- a/src/composables/event_handler.js
+++ b/src/composables/event_handler.js
@@ -171,9 +171,10 @@ function strToLines (str) {
 }
 
 export function useEventHandler () {
-  function onEvent (cmd, msg) {
+  function onEvent (cmd, msg, id) {
     if (handlers[cmd]) {
-      handlers[cmd](msg)
+      // Do not print in output if and ID has been passed to cmd
+      id ? null : handlers[cmd](msg)
       return
     }
 

--- a/src/composables/helpers.js
+++ b/src/composables/helpers.js
@@ -1,25 +1,29 @@
 import { action_mapper } from '@/composables/constants/action_mapper';
 
 export function helpers() {
-    function copperToMoneyString(amount) {
+    function copperToMoneyString(amount, short) {
         let valueString = '';
         let copperString = amount.toString();
 
+        const gold = short ? 'g ' : ' gold, '
+        const silver = short ? 's ' : ' silver, '
+        const copper = short ? 'c ' : ' copper '
+
         if (copperString.length > 4) {
-            valueString = "<span class='bold-yellow'>" + copperString.slice(0, copperString.length - 4) + " gold, " + "</span>"
+            valueString = "<span class='bold-yellow'>" + copperString.slice(0, copperString.length - 4) + gold + "</span>"
             copperString = copperString.slice(copperString.length - 4, copperString.length)
         }
 
         if (copperString.length > 2) {
-            valueString += copperString.slice(0, copperString.length - 2) + " silver, "
+            valueString += "<span class='bold-white'>" + copperString.slice(0, copperString.length - 2) + silver + "</span>"
             copperString = copperString.slice(copperString.length - 2, copperString.length)
         }
 
         if (copperString === "00") {
-            copperString = "0"
+            return valueString;
         }
 
-        valueString += "<span class='bold-cyan'>" + copperString + " copper"  + "</span>"
+        valueString += "<span class='bold-cyan'>" + copperString + copper + "</span>"
 
         return valueString;
     }

--- a/src/composables/state.js
+++ b/src/composables/state.js
@@ -1,4 +1,4 @@
-import { reactive } from "vue"
+import { reactive, ref } from "vue"
 
 export const state = reactive({
   options: {
@@ -19,6 +19,7 @@ export const state = reactive({
 
   entityCache: {},
   itemCache: {},
+  commandCache: {},
 
   connected: false,
 
@@ -75,6 +76,11 @@ export const state = reactive({
     },
     map: [],
     slots: []
+  },
+  modal: {
+    visible: false,
+    item: ref({}),
+    menu: ''
   }
 })
 

--- a/src/composables/web_socket.js
+++ b/src/composables/web_socket.js
@@ -17,10 +17,14 @@ export function useWebSocket () {
     const _onMessage = (json) => {
       try {
         let { cmd, msg, id } = JSON.parse(json)
+        if (id) {
+          state.commandCache[id] = msg
+        }
         if (process.env.NODE_ENV != 'production') {
           console.log(`<- ${cmd} ${msg ? JSON.stringify(msg) : ''} ${id ? ` (id=${id})` : ''}`)
         }
-        onEvent(cmd, msg)
+
+        id ? onEvent(cmd, msg, id) : onEvent(cmd, msg)
       } catch (err) {
         console.log('error parsing message: %s', json)
         console.log(err.stack)
@@ -40,9 +44,11 @@ export function useWebSocket () {
   }
 
   function cmd (command, id) {
-    addLine('', 'output')
-    addLine(`<span class="player-cmd-caret">></span> <span class="player-cmd">${command}</span>`, 'output')
-    addLine('', 'output')
+    if (!id) {
+      addLine('', 'output')
+      addLine(`<span class="player-cmd-caret">></span> <span class="player-cmd">${command}</span>`, 'output')
+      addLine('', 'output')
+    }
     send('cmd', command, id)
   }
 

--- a/src/composables/web_socket.js
+++ b/src/composables/web_socket.js
@@ -45,9 +45,15 @@ export function useWebSocket () {
 
   function cmd (command, id) {
     if (!id) {
-      addLine('', 'output')
-      addLine(`<span class="player-cmd-caret">></span> <span class="player-cmd">${command}</span>`, 'output')
-      addLine('', 'output')
+      // Crude filter to avoid shouing the ugly 'look iid:123456' in the output
+      const lcCmd = command.toLowerCase()
+      const excludeIIDCommand = lcCmd.includes('iid:') && !lcCmd.includes('gossip ') && !lcCmd.includes('say ')
+          && !lcCmd.includes('trade ') && !lcCmd.includes('newbie ')
+      if (!excludeIIDCommand) {
+        addLine('', 'output')
+        addLine(`<span class="player-cmd-caret">></span> <span class="player-cmd">${command}</span>`, 'output')
+        addLine('', 'output')
+      }
     }
     send('cmd', command, id)
   }

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -24,6 +24,7 @@
     </n-layout-sider>
 
     <n-layout>
+      <ModalCard></ModalCard>
       <div class="content-area">
         <LineOutput></LineOutput>
       </div>
@@ -66,6 +67,7 @@ import MoveControls from '@/components/MoveControls.vue'
 import QuickStats from '@/components/QuickStats.vue'
 import MapActions from '@/components/MapActions.vue'
 import HelpOverlay from '@/components/HelpOverlay.vue'
+import ModalCard from '@/components/ModalCard'
 
 import { useWindowHandler } from '@/composables/window_handler'
 
@@ -120,6 +122,10 @@ try {
 }
 
 .n-layout {
+  z-index: 1;
+}
+
+.n-layout-sider {
   z-index: 2;
 }
 


### PR DESCRIPTION
This PR adds inventory and equipment modals. The changes come as preparation and practice for future work which will implement various modals (crafting, mercenary management, map). **This is dependent on a recent backend change** which allows the UI to grab the output of a single command by passing an id to the command. 

The PR also brings minor accessibility improvements for screen readers.

This has been tested on mobile too, and in my opinion it looks good. We do have a few players who use mobile, so we might adjust things based on their input. 

**Sreenshots**

![image](https://user-images.githubusercontent.com/11844042/194765574-7715a4c4-c994-456e-bbad-a51046b7349a.png)

![image](https://user-images.githubusercontent.com/11844042/194765653-41b6101c-f353-4ca0-b4c8-45254282535e.png)

