### PR TITLE
Clear item cache

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -16,6 +16,7 @@ import { useCookieHandler } from './composables/cookie_handler'
 import { useEventHandler } from './composables/event_handler'
 import { useWebSocket } from './composables/web_socket'
 import { useWindowHandler } from './composables/window_handler'
+import { constants } from './composables/constants/constants'
 
 import SplashScreen from '@/components/SplashScreen.vue'
 import LoginModal from './components/modals/LoginModal.vue'
@@ -70,6 +71,20 @@ function onClose () {
 }
 
 onMounted(doConnect)
+
+setInterval(() => {
+  const now = Date.now()
+  const keys = Object.keys(state.itemCache)
+
+  keys.map(key => {
+    const itemDate = state.itemCache[key].date
+    const difference = now - itemDate
+
+    if (difference > constants.CACHE_DELETE_TIME) {
+      delete state.itemCache[key]
+    }
+  })
+}, constants.CACHE_DELETE_INTERVAL)
 </script>
 
 <style lang="less">

--- a/src/composables/constants/constants.js
+++ b/src/composables/constants/constants.js
@@ -1,0 +1,4 @@
+export const constants = {
+    CACHE_DELETE_TIME: 1200000, // 20 minutes
+    CACHE_DELETE_INTERVAL: 900000 // 15 minutes
+}

--- a/src/composables/event_handler.js
+++ b/src/composables/event_handler.js
@@ -193,7 +193,7 @@ export function useEventHandler () {
     if (matches && state.pendingRequests[cmd]) {
       let iid = parseInt(matches[1], 10)
       let { resolve, timeout } = state.pendingRequests[cmd]
-      state.itemCache[iid] = msg
+      state.itemCache[iid] = { item: msg, date: Date.now() }
       delete state.pendingRequests[cmd]
       clearTimeout(timeout)
       resolve(msg)

--- a/src/composables/web_socket.js
+++ b/src/composables/web_socket.js
@@ -82,7 +82,7 @@ export function useWebSocket () {
 
   function fetchItem (iid)  {
     if (state.itemCache[iid]) {
-      return new Promise((resolve) => resolve(state.itemCache[iid]))
+      return new Promise((resolve) => resolve(state.itemCache[iid].item))
     }
 
     const requestId = `item-${iid}`


### PR DESCRIPTION
It has come to our attention that there were performance issues affecting the web client. The items seem to have been resolved now, but in light of performance issues, the current cache systems we have are never cleared. That means that sooner or later these systems will get large and may create performance issues. 

This PR proposes a clearing system. This is currently applied to only one of the caches, but I will update the rest if this approach is okay. 