### PR TITLE
Merc modal preparations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ pnpm-debug.log*
 *.njsproj
 *.sln
 *.sw?
+.editorconfig

--- a/src/components/modals/MercModal.vue
+++ b/src/components/modals/MercModal.vue
@@ -1,0 +1,29 @@
+<template>
+	<n-card>
+		<p class="close" v-on:click="closeModal()">x</p>
+	</n-card>
+</template>
+
+<script setup>
+import { watch } from 'vue'
+import { NCard } from 'naive-ui'
+import { state } from '@/composables/state'
+
+watch(() => state.gameState.party, function() {
+	console.log("updated")
+})
+
+function closeModal() {	
+  state.modals.mercModal = false
+}
+</script>
+
+<style>
+
+.n-card {
+  position: absolute;
+  max-width: 5vw;
+  margin-top: 35px;
+  z-index: 2;
+}
+</style>

--- a/src/components/modals/MercModal.vue
+++ b/src/components/modals/MercModal.vue
@@ -1,30 +1,94 @@
 <template>
-  <n-card>
+  <n-card :class="state.options.swapControls ? 'left' : 'right'" v-if="state.modals.mercModal">
     <p class="close" v-on:click="closeModal()">x</p>
+    <h3 class="bold-green"> {{merc.name}} </h3>
+    <div class="affects">
+      <span v-for="(affect, index) in affects" 
+            v-html="ansiToHtml(affect) + ' '" 
+            v-bind:key='index'></span>
+    </div>
+    <QuickStats :entity="merc"></QuickStats>
   </n-card>
 </template>
 
 <script setup>
-// TODO This modal needs to be added to src/views/GameView.vue once it is completed
-import { watch } from 'vue'
+// TODO This modal is not completed yet so the player does not have a way to show it yet
+import { watch, ref, onMounted } from 'vue'
 import { NCard } from 'naive-ui'
 import { state } from '@/composables/state'
+import { helpers } from '@/composables/helpers'
+
+import QuickStats from '@/components/side-menu/QuickStats.vue'
+
+const { ansiToHtml } = helpers() 
+const merc = ref({})
+const affects = ref([])
 
 watch(() => state.gameState.party, function() {
-	console.log("updated")
+  findAndSetMerc()
+})
+
+onMounted(() => {
+  findAndSetMerc()
 })
 
 function closeModal() {	
   state.modals.mercModal = false
 }
+
+function findAndSetMerc() {
+  if (state.gameState.party) {
+    state.gameState.party.map(entity => {
+      if (entity.name.includes(" the ")) {
+        merc.value = entity
+      }
+    })
+  }
+  // Some of the affects will just be null, filtering those out
+  const newAffects = []
+  if (merc.value.affects) {
+    merc.value.affects.map(affect => {
+      if (affect !== null) {
+        newAffects.push(affect)
+      }
+    })
+  }
+  affects.value = newAffects
+}
+
 </script>
 
 <style scoped>
 
 .n-card {
   position: absolute;
-  max-width: 5vw;
+  width: 25rem;
   margin-top: 35px;
   z-index: 2;
+  max-height: 80vh;
+}
+
+.right {
+  right: 5px;
+}
+
+.left {
+  left: 5px;
+}
+
+.close {
+  position: absolute;
+  top: -10px;
+  right: 10px;
+  cursor: pointer;
+  font-size: 1.4em;
+}
+
+@media screen and (max-width: 1000px) {
+  .n-card {
+    width: 98%;
+    margin-top: 5px;
+    max-height: 95%;
+  }
 }
 </style>

--- a/src/components/modals/MercModal.vue
+++ b/src/components/modals/MercModal.vue
@@ -1,10 +1,11 @@
 <template>
-	<n-card>
-		<p class="close" v-on:click="closeModal()">x</p>
-	</n-card>
+  <n-card>
+    <p class="close" v-on:click="closeModal()">x</p>
+  </n-card>
 </template>
 
 <script setup>
+// TODO This modal needs to be added to src/views/GameView.vue once it is completed
 import { watch } from 'vue'
 import { NCard } from 'naive-ui'
 import { state } from '@/composables/state'

--- a/src/components/modals/MercModal.vue
+++ b/src/components/modals/MercModal.vue
@@ -18,7 +18,7 @@ function closeModal() {
 }
 </script>
 
-<style>
+<style scoped>
 
 .n-card {
   position: absolute;

--- a/src/components/modals/MercModal.vue
+++ b/src/components/modals/MercModal.vue
@@ -17,11 +17,16 @@ import { watch, ref, onMounted } from 'vue'
 import { NCard } from 'naive-ui'
 import { state } from '@/composables/state'
 import { helpers } from '@/composables/helpers'
+import { constants } from '@/composables/constants/constants'
+import { useWebSocket } from '@/composables/web_socket'
 
 import QuickStats from '@/components/side-menu/QuickStats.vue'
 
 const { ansiToHtml } = helpers() 
+const { fetchEntity } = useWebSocket()
+
 const merc = ref({})
+const mercEntity = ref({})
 const affects = ref([])
 
 watch(() => state.gameState.party, function() {
@@ -37,10 +42,14 @@ function closeModal() {
 }
 
 function findAndSetMerc() {
+  console.log(state.gameState.party)
   if (state.gameState.party) {
-    state.gameState.party.map(entity => {
-      if (entity.name.includes(" the ")) {
-        merc.value = entity
+    state.gameState.party.map(async entity => {
+      if (entity.traits.includes(constants.TRAITS_MERCENARY)) {
+        mercEntity.value = await fetchEntity(entity.eid)
+        if (mercEntity.value.target !== {}) {
+          merc.value = entity
+        }
       }
     })
   }

--- a/src/components/modals/ModalCard.vue
+++ b/src/components/modals/ModalCard.vue
@@ -104,9 +104,13 @@ function clickedAction(action) {
 
 function dropAll() {
   cmd(`drop all iid:${item.value.iid}`)
+  closeModal()
 }
 
 function dropItems() {
+  if (dropValue.value === item.value.amount) {
+    closeModal()
+  }
   cmd(`drop ${dropValue.value}x iid:${item.value.iid}`)
 }
 

--- a/src/components/modals/ModalCard.vue
+++ b/src/components/modals/ModalCard.vue
@@ -19,7 +19,7 @@
               {{action.split(" ").length > 1 ? action.split(" ")[1] : action}}
             </n-button>
           </div>
-          <n-collapse>
+          <n-collapse v-if="state.modals.inventoryModal.menu === 'inventory'" class="additional-collapse">
             <n-collapse-item title="Additional actions">
               <div class="additional-actions">
                 <n-button ghost type="error" @click="dropAll()">
@@ -211,6 +211,10 @@ h3 {
   .action {
     text-transform: capitalize;
   }
+}
+
+.additional-collapse {
+  margin-top: 15px;
 }
 
 .input-button {

--- a/src/components/modals/ModalCard.vue
+++ b/src/components/modals/ModalCard.vue
@@ -19,21 +19,21 @@
               {{action.split(" ").length > 1 ? action.split(" ")[1] : action}}
             </n-button>
           </div>
-					<n-collapse>
-						<n-collapse-item title="Additional actions">
-							<div class="additional-actions">
-							<n-button ghost type="error" @click="dropAll()">
-								Drop all
-							</n-button>
-							<div class="input-button">
-								<n-button ghost type="error" @click="dropItems()">
-									Drop
-								</n-button>
-								<n-input-number class="input-field" button-placement="both" v-model:value="dropValue" min=1 :max="item.amount" />
-							</div>
-							</div>
-						</n-collapse-item>
-					</n-collapse>
+          <n-collapse>
+            <n-collapse-item title="Additional actions">
+              <div class="additional-actions">
+                <n-button ghost type="error" @click="dropAll()">
+                  Drop all
+                </n-button>
+                <div class="input-button">
+                  <n-button ghost type="error" @click="dropItems()">
+                    Drop
+                  </n-button>
+                  <n-input-number class="input-field" button-placement="both" v-model:value="dropValue" min=1 :max="item.amount" />
+                </div>
+              </div>
+            </n-collapse-item>
+          </n-collapse>
         </n-tab-pane>
         <n-tab-pane name="look" tab="Look">
           <div class="item-desc" v-html="ansiToHtml(item.description)"></div>
@@ -74,7 +74,7 @@ watch(() => state.modals.inventoryModal.item, () => {
     cmd(`examine iid:${item.value.iid}`, commandCacheKey)
     setActions()
   }
-	dropValue.value = 1
+  dropValue.value = 1
 })
 
 watch(() => state.modals.inventoryModal.menu, () => {
@@ -103,11 +103,11 @@ function clickedAction(action) {
 }
 
 function dropAll() {
-	cmd(`drop all iid:${item.value.iid}`)
+  cmd(`drop all iid:${item.value.iid}`)
 }
 
 function dropItems() {
-	cmd(`drop ${dropValue.value}x iid:${item.value.iid}`)
+  cmd(`drop ${dropValue.value}x iid:${item.value.iid}`)
 }
 
 // Setters
@@ -214,18 +214,18 @@ h3 {
 }
 
 .input-button {
-	display: flex;
+  display: flex;
 }
 
 .additional-actions {
-	display: grid;
-	grid-template-columns: 1fr 2fr;
-	gap: 15px;
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 15px;
 }
 
 .input-field {
-	margin-left: 5px;
-	width: 100px;
+  margin-left: 5px;
+  width: 100px;
 }
 
 @media screen and (max-width: 1000px) {

--- a/src/components/modals/ModalCard.vue
+++ b/src/components/modals/ModalCard.vue
@@ -19,6 +19,21 @@
               {{action.split(" ").length > 1 ? action.split(" ")[1] : action}}
             </n-button>
           </div>
+					<n-collapse>
+						<n-collapse-item title="Additional actions">
+							<div class="additional-actions">
+							<n-button ghost type="error" @click="dropAll()">
+								Drop all
+							</n-button>
+							<div class="input-button">
+								<n-button ghost type="error" @click="dropItems()">
+									Drop
+								</n-button>
+								<n-input-number class="input-field" button-placement="both" v-model:value="dropValue" min=1 :max="item.amount" />
+							</div>
+							</div>
+						</n-collapse-item>
+					</n-collapse>
         </n-tab-pane>
         <n-tab-pane name="look" tab="Look">
           <div class="item-desc" v-html="ansiToHtml(item.description)"></div>
@@ -31,7 +46,7 @@
 </template>
 
 <script setup>
-import { NCard, NButton, NTabs, NTabPane } from 'naive-ui'
+import { NCard, NButton, NTabs, NTabPane, NCollapse, NCollapseItem, NInputNumber } from 'naive-ui'
 import { ref, watch } from 'vue'
 import { useWebSocket } from '@/composables/web_socket'
 import { state } from '@/composables/state'
@@ -48,6 +63,7 @@ const actions = ref(getActions({
   type: item.value.type,
   subtype: item.value.subtype
 }))
+const dropValue = ref(1)
 
 // Watchers
 
@@ -58,6 +74,7 @@ watch(() => state.modals.inventoryModal.item, () => {
     cmd(`examine iid:${item.value.iid}`, commandCacheKey)
     setActions()
   }
+	dropValue.value = 1
 })
 
 watch(() => state.modals.inventoryModal.menu, () => {
@@ -83,6 +100,14 @@ function clickedAction(action) {
     closeModal()
   }
   cmd(`${action} iid:${item.value.iid}`)
+}
+
+function dropAll() {
+	cmd(`drop all iid:${item.value.iid}`)
+}
+
+function dropItems() {
+	cmd(`drop ${dropValue.value}x iid:${item.value.iid}`)
 }
 
 // Setters
@@ -186,6 +211,21 @@ h3 {
   .action {
     text-transform: capitalize;
   }
+}
+
+.input-button {
+	display: flex;
+}
+
+.additional-actions {
+	display: grid;
+	grid-template-columns: 1fr 2fr;
+	gap: 15px;
+}
+
+.input-field {
+	margin-left: 5px;
+	width: 100px;
 }
 
 @media screen and (max-width: 1000px) {

--- a/src/components/side-menu/QuickStats.vue
+++ b/src/components/side-menu/QuickStats.vue
@@ -1,34 +1,34 @@
 <template>
   <div class="stats">
-    <n-progress class="quick-stats" type="line" status="success" :percentage="player().hp / player().maxHp * 100">
+    <n-progress class="quick-stats" type="line" status="success" :percentage="entity().hp / entity().maxHp * 100">
       <div class="bar-label">
-        <span class="bold-green">{{ player().hp }}</span> <span class="green">HP</span>
+        <span class="bold-green">{{ entity().hp }}</span> <span class="green">HP</span>
       </div>
     </n-progress>
-    <n-progress class="quick-stats" type="line" status="default" :percentage="player().energy / player().maxEnergy * 100">
+    <n-progress class="quick-stats" type="line" status="default" :percentage="entity().energy / entity().maxEnergy * 100">
       <div class="bar-label">
-        <span class="bold-cyan">{{ player().energy }}</span> <span class="cyan">EN</span>
+        <span class="bold-cyan">{{ entity().energy }}</span> <span class="cyan">EN</span>
       </div>
     </n-progress>
-    <n-progress class="quick-stats" type="line" status="warning" :percentage="player().stamina / player().maxStamina * 100">
+    <n-progress class="quick-stats" type="line" status="warning" :percentage="entity().stamina / entity().maxStamina * 100">
       <div class="bar-label">
-        <span class="bold-yellow">{{ player().stamina }}</span> <span class="yellow">ST</span>
+        <span class="bold-yellow">{{ entity().stamina }}</span> <span class="yellow">ST</span>
       </div>
     </n-progress>
-    <n-progress class="quick-stats" type="line" status="success" :percentage="player().food / player().maxFood * 100">
+    <n-progress class="quick-stats" type="line" status="success" :percentage="entity().food / entity().maxFood * 100">
       <div class="bar-label">
-        <span class="bold-green">{{ player().food }}</span> <span class="green">FD</span>
+        <span class="bold-green">{{ entity().food }}</span> <span class="green">FD</span>
       </div>
     </n-progress>
     <div class="flex">
-      <n-progress class="quick-stats" type="line" status="warning" :percentage="player().combo / player().maxCombo * 100">
+      <n-progress class="quick-stats" type="line" status="warning" :percentage="entity().combo / entity().maxCombo * 100">
         <div class="half-bar-label">
-          <span class="bold-yellow">{{ player().combo }}</span> <span class="yellow">CB</span>
+          <span class="bold-yellow">{{ entity().combo }}</span> <span class="yellow">CB</span>
         </div>
       </n-progress>
-      <n-progress class="quick-stats" type="line" status="danger" :percentage="player().rage / player().maxRage * 100">
+      <n-progress class="quick-stats" type="line" status="danger" :percentage="entity().rage / entity().maxRage * 100">
         <div class="half-bar-label">
-          <span class="bold-red">{{ player().rage }}</span> <span class="red">RG</span>
+          <span class="bold-red">{{ entity().rage }}</span> <span class="red">RG</span>
         </div>
       </n-progress>
     </div>
@@ -37,10 +37,12 @@
 
 <script setup>
 import { NProgress } from 'naive-ui'
-import { state } from '@/composables/state'
+import { defineProps } from '@/composables/state'
 
-function player () {
-  return state.gameState.player || {}
+const props = defineProps(['entity'])
+
+function entity () {
+  return props.entity || {}
 }
 </script>
 
@@ -58,7 +60,6 @@ function player () {
   .flex {
     display: flex;
     flex-direction: row;
-    line-height: 1.1;
     .quick-stats {
       margin-right: 10px;
       &:last-child {

--- a/src/components/side-menu/SideMenu.vue
+++ b/src/components/side-menu/SideMenu.vue
@@ -14,7 +14,7 @@
           <n-icon class="map-icon" v-on:click="toggleMap()"><MapOutlined /></n-icon>
           <MiniMap></MiniMap>
         </div>
-        <QuickStats></QuickStats>
+        <QuickStats :entity="state.gameState.player"></QuickStats>
       </div>
     </div>
   </n-layout-sider>

--- a/src/composables/constants/constants.js
+++ b/src/composables/constants/constants.js
@@ -1,4 +1,5 @@
 export const constants = {
     CACHE_DELETE_TIME: 1200000, // 20 minutes
-    CACHE_DELETE_INTERVAL: 900000 // 15 minutes
+    CACHE_DELETE_INTERVAL: 900000, // 15 minutes
+    TRAITS_MERCENARY: "mercenary"
 }

--- a/src/composables/state.js
+++ b/src/composables/state.js
@@ -86,7 +86,8 @@ export const state = reactive({
       item: ref({}),
       menu: ''
     },
-    mapModal: false
+    mapModal: false,
+		mercModal: false
   }
 })
 

--- a/src/composables/state.js
+++ b/src/composables/state.js
@@ -87,7 +87,7 @@ export const state = reactive({
       menu: ''
     },
     mapModal: false,
-		mercModal: false
+    mercModal: false
   }
 })
 

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -8,6 +8,7 @@
     <n-layout>
       <ModalCard></ModalCard>
       <MapModal></MapModal>
+			<MercModal></MercModal>
       <div class="content-area">
         <LineOutput></LineOutput>
       </div>
@@ -28,6 +29,7 @@ import HelpOverlay from '@/components/HelpOverlay.vue'
 import ModalCard from '@/components/modals/ModalCard'
 import MapModal from '@/components/modals/MapModal'
 import SideMenu from '@/components/side-menu/SideMenu'
+import MercModal from '@/components/modals/MercModal'
 
 try {
   const options = JSON.parse(localStorage.getItem('options'))

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -8,7 +8,6 @@
     <n-layout>
       <ModalCard></ModalCard>
       <MapModal></MapModal>
-			<MercModal></MercModal>
       <div class="content-area">
         <LineOutput></LineOutput>
       </div>

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -10,6 +10,7 @@
     <n-layout>
       <ModalCard></ModalCard>
       <MapModal></MapModal>
+      <MercModal></MercModal>
       <div class="content-area">
         <LineOutput></LineOutput>
       </div>
@@ -29,6 +30,7 @@ import LogoutModal from '@/components/modals/LogoutModal.vue'
 import HelpOverlay from '@/components/HelpOverlay.vue'
 import ModalCard from '@/components/modals/ModalCard'
 import MapModal from '@/components/modals/MapModal'
+import MercModal from '@/components/modals/MercModal'
 import SideMenu from '@/components/side-menu/SideMenu'
 
 try {

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -3,7 +3,9 @@
 
   <HelpOverlay></HelpOverlay>
 
-  <n-layout has-sider v-if="state.token && state.connected" :class="getDirection()" :sider-placement="state.options.swapControls ? 'right' : 'left'">
+  <n-layout has-sider 
+    v-if="state.token && state.connected" class="game" 
+    :sider-placement="state.options.swapControls ? 'right' : 'left'">
     <SideMenu v-if="!state.options.swapControls"></SideMenu>
     <n-layout>
       <ModalCard></ModalCard>
@@ -28,7 +30,6 @@ import HelpOverlay from '@/components/HelpOverlay.vue'
 import ModalCard from '@/components/modals/ModalCard'
 import MapModal from '@/components/modals/MapModal'
 import SideMenu from '@/components/side-menu/SideMenu'
-import MercModal from '@/components/modals/MercModal'
 
 try {
   const options = JSON.parse(localStorage.getItem('options'))
@@ -40,12 +41,6 @@ try {
   localStorage.setItem('options', '')
 }
 
-function getDirection() {
-  if (state.options.swapControls) {
-    return 'game right-side'
-  }
-  return 'game left-side'
-}
 </script>
 
 <style lang="less">


### PR DESCRIPTION
This PR does a bit of refactoring related to the merc modal. I also added the `Additional actions` section tot he inventory modal, where players can `Drop all` or `Drop amount` for items. In this section we will have `Give all` and `Give amount` in relation to the mercenary. This was not included in this PR due to reasons explained further below.

A merc modal window is also added, but completely hidden from players (they won't be able to open the window). The reason for hiding it ( and not adding the `Give all` and `Give amount` buttons ) is that the way I am currently the merc data is less than ideal. I am looping through the party members in `state.gameState.party` and selecting the one which has ` the ` in its name. This can cause all kind of issues, as you can imagine. 

**Inventory modal addition**

![drop demo](https://user-images.githubusercontent.com/11844042/197007135-17678310-bddf-49b5-a439-072fcc6d85b5.gif)

**Merc modal closeup (completely inactive as of now)**

![merc modal closeup](https://user-images.githubusercontent.com/11844042/197007223-11932ee2-f103-4a8a-844b-c8b9d99563da.png)

**Merc modal positioning (completely inactive as of now)**

![merc modal big](https://user-images.githubusercontent.com/11844042/197007299-7febffa8-cdd8-4ed2-93e3-b08299031fd9.png)

