### PR TITLE
Add Statistics, Effects and Skills dropdowns to the merc modal

### DIFF
--- a/src/components/modals/MercModal.vue
+++ b/src/components/modals/MercModal.vue
@@ -12,13 +12,30 @@
       </n-tooltip>
     </div>
     <QuickStats :entity="mercVitals"></QuickStats>
+    <n-collapse>
+      <CharacterCollapse
+          :character="mercEntity"
+          :is-player="false"
+      ></CharacterCollapse>
+      <EffectsCollapse
+          :affects="affects"
+      ></EffectsCollapse>
+      <SkillsCollapse
+          :character="mercEntity"
+          :skills="mercSkills"
+          :isPlayer="false"
+      ></SkillsCollapse>
+    </n-collapse>
   </n-card>
 </template>
 
 <script setup>
 // TODO This modal is not completed yet so the player does not have a way to show it yet
 import { watch, ref, onMounted } from 'vue'
-import { NCard, NTooltip } from 'naive-ui'
+import { NCard, NTooltip, NCollapse } from 'naive-ui'
+import CharacterCollapse from '@/components/side-menu/collapse-items/CharacterCollapse.vue'
+import SkillsCollapse from '@/components/side-menu/collapse-items/SkillsCollapse.vue'
+import EffectsCollapse from '@/components/side-menu/collapse-items/EffectsCollapse.vue'
 
 import { state } from '@/composables/state'
 import { helpers } from '@/composables/helpers'
@@ -30,6 +47,7 @@ const { ansiToHtml } = helpers()
 const mercVitals = ref({})
 const mercEntity = ref({})
 const affects = ref([])
+const mercSkills = ref([])
 
 watch(() => state.gameState.party, function() {
   findAndSetMerc()
@@ -54,6 +72,7 @@ async function findAndSetMerc() {
   mercEntity.value = merc.stats
   state.gameState.mercEid = merc.stats.eid
   mercVitals.value = merc.stats
+  mercSkills.value = merc.skills
 
   setAffects(merc.affects)
 }
@@ -84,6 +103,7 @@ function setAffects(affectList) {
   margin-top: 35px;
   z-index: 2;
   max-height: 80vh;
+  overflow-y: scroll;
 }
 
 .right {
@@ -104,6 +124,10 @@ function setAffects(affectList) {
 
 .longflag {
   text-transform: capitalize;
+}
+
+.n-collapse {
+  margin-top: 20px;
 }
 
 @media screen and (max-width: 1000px) {

--- a/src/components/side-menu/PlayerStats.vue
+++ b/src/components/side-menu/PlayerStats.vue
@@ -11,12 +11,21 @@
     </n-progress>
 
     <n-collapse>
-      <CharacterCollapse></CharacterCollapse>
-      <EffectsCollapse></EffectsCollapse>
+      <CharacterCollapse
+          :character="state.gameState.player"
+          :is-player="true"
+      ></CharacterCollapse>
+      <EffectsCollapse
+          :affects="state.gameState.affects"
+      ></EffectsCollapse>
       <InventoryCollapse></InventoryCollapse>
       <EquipmentCollapse></EquipmentCollapse>
       <QuestCollapse></QuestCollapse>
-      <SkillsCollapse></SkillsCollapse>
+      <SkillsCollapse
+          :character="state.gameState.player"
+          :skills="state.gameState.skills"
+          :isPlayer="true"
+      ></SkillsCollapse>
       <OptionsCollapse></OptionsCollapse>
     </n-collapse>
   </div>

--- a/src/components/side-menu/collapse-items/CharacterCollapse.vue
+++ b/src/components/side-menu/collapse-items/CharacterCollapse.vue
@@ -2,7 +2,7 @@
   <n-collapse-item title="Statistics">
 
     <div class="ability-points" v-if="player().abilityPoints > 0">
-      You have <span class="bold-yellow">1</span> unspent ability points. Use the point command or the <n-icon class="inline"><AddBoxOutlined></AddBoxOutlined></n-icon> symbol below to spend them.
+      You have <span class="bold-yellow">{{ player().abilityPoints }}</span> unspent ability points. Use the point command or the <n-icon class="inline"><AddBoxOutlined></AddBoxOutlined></n-icon> symbol below to spend them.
     </div>
 
     <div class="stat-row">
@@ -178,16 +178,17 @@
 
 <script setup>
 import { NCollapseItem, NIcon } from 'naive-ui'
+import { defineProps } from 'vue'
 
 import AddBoxOutlined from '@vicons/material/AddBoxOutlined'
 
-import { state } from '@/composables/state'
 import { useWebSocket } from '@/composables/web_socket'
 
 const { cmd } = useWebSocket()
+const props = defineProps(['character', 'isPlayer'])
 
 function player () {
-  return state.gameState.player || {}
+  return props.character || {}
 }
 
 function renderNumber (value, digits = 2) {
@@ -199,7 +200,8 @@ function renderNumber (value, digits = 2) {
 }
 
 function addStatPoint (stat) {
-  cmd("point " + stat)
+  const command = props.isPlayer ? `point ${stat}` : `order eid:${props.character.eid} point ${stat}`
+  cmd(command)
 }
 </script>
 
@@ -207,10 +209,13 @@ function addStatPoint (stat) {
 .stat-row {
   display: flex;
   flex-direction: row;
+  justify-content: center;
+  width: 100%;
   .stat {
     display: flex;
     flex-direction: row;
     width: 65%;
+    justify-content: space-around;
     .label {
       color: #aaa;
       width: 70px;

--- a/src/components/side-menu/collapse-items/EffectsCollapse.vue
+++ b/src/components/side-menu/collapse-items/EffectsCollapse.vue
@@ -3,9 +3,10 @@
     <div class="effects">
       <div v-if="effects().length == 0">You are not affected by anything.</div>
       <div class="effect" v-for="effect in effects()" :key="effect.name">
-        <n-progress type="line" status="default" :percentage="getEffectPercentage(effect)">
+        <n-progress type="line" status="default" :percentage="getEffectPercentage(effect)" v-if="!effect.longFlag.includes('Hired')">
           <div v-html="getEffectName(effect)"></div>
         </n-progress>
+        <div v-if="effect.longFlag.includes('Hired')" v-html="getEffectName(effect)" class="hired"></div>
         <div v-if="effect.desc">{{ effect.desc }}</div>
         <div class="effect-bonuses">
           <div class="effect-bonus" v-for="(bonus, i) in getEffectBonuses(effect)" :key="`bouns-${i}`" v-html="bonus"></div>
@@ -17,13 +18,14 @@
 
 <script setup>
 import { NProgress, NCollapseItem } from 'naive-ui'
-import { state } from '@/composables/state'
 import { helpers } from '@/composables/helpers'
+import { defineProps } from 'vue'
 
+const props = defineProps(['affects'])
 const { ansiToHtml } = helpers()
 
 function effects () {
-  return state.gameState.affects || []
+  return props.affects || []
 }
 
 function getEffectName (effect) {
@@ -76,6 +78,9 @@ function getEffectBonuses (effect) {
       flex-direction: row;
       flex-wrap: wrap;
       justify-content: space-between;
+      width: 100%;
+    }
+    .hired {
       width: 100%;
     }
   }

--- a/src/components/side-menu/collapse-items/SkillsCollapse.vue
+++ b/src/components/side-menu/collapse-items/SkillsCollapse.vue
@@ -12,7 +12,7 @@
         <!-- <div>{{ skill }}</div> -->
       </div>
 
-      <div class="skill-type bold-magenta">Crafting Skills</div>
+      <div class="skill-type bold-magenta" v-if="props.isPlayer">Crafting Skills</div>
       <div class="points" v-if="player().craftingPoints > 0">
         You have <span class="bold-magenta">{{ player().craftingPoints }}</span> unspent crafting points. Find a crafting skill book to read.
       </div>
@@ -42,14 +42,16 @@
 
 <script setup>
 import { NCollapseItem, NProgress } from 'naive-ui'
-import { state } from '@/composables/state'
+import { defineProps } from 'vue'
+
+const props = defineProps(['character', 'skills', 'isPlayer'])
 
 function skills () {
-  return state.gameState.skills || []
+  return props.skills || []
 }
 
 function player () {
-  return state.gameState.player
+  return props.character
 }
 
 </script>

--- a/src/composables/web_socket.js
+++ b/src/composables/web_socket.js
@@ -51,7 +51,7 @@ export function useWebSocket () {
     if (!id) {
       // Crude filter to avoid shouing the ugly 'look iid:123456' in the output
       const lcCmd = command.toLowerCase()
-      const excludeIIDCommand = lcCmd.includes('iid:') && !lcCmd.includes('chat ') && !lcCmd.includes('say ')
+      const excludeIIDCommand = (lcCmd.includes('iid:') || lcCmd.includes('eid:')) && !lcCmd.includes('chat ') && !lcCmd.includes('say ')
           && !lcCmd.includes('trade ') && !lcCmd.includes('newbie ')
       if (!excludeIIDCommand) {
         addLine('', 'output')


### PR DESCRIPTION
Following yesterday's changes, I am now adding 3 dropdowns to the Merc Modal: 

**Statistics**
![statistics](https://user-images.githubusercontent.com/11844042/219648114-7736f904-3da9-4ccc-8775-149309a41a7f.png)

**Effects**
![effects](https://user-images.githubusercontent.com/11844042/219648132-a64e617a-ae60-47a7-9ab6-7ab58c2025b8.png)

**Skills**
![skills](https://user-images.githubusercontent.com/11844042/219648162-00d249d2-b6a5-446a-a75d-0317686bb117.png)
