### PR TITLE
Minor fixes, and rage bar instead of rage circle

### DIFF
--- a/src/components/side-menu/QuickStats.vue
+++ b/src/components/side-menu/QuickStats.vue
@@ -18,11 +18,19 @@
         <span class="label yellow">ST</span>
         <n-progress class="quick-stats" type="line" status="warning" :percentage="entity().stamina / entity().maxStamina * 100" :show-indicator="false"></n-progress>
       </span>
+
+      <span class="stat" v-if="entity().rage > 0">
+        <span class="value bold-red">{{ entity().rage }}</span>
+        <span class="label red">RG</span>
+        <n-progress class="quick-stats" type="line" status="warning" :percentage="entity().rage / entity().maxRage * 100" :show-indicator="false"></n-progress>
+      </span>
     </span>
 
     <span class="right">
       <n-progress class="circle-stat" type="circle" status="success" :percentage="entity().food / entity().maxFood * 100">Food</n-progress>
+<!--
       <n-progress v-if="entity().rage > 0" class="circle-stat" type="circle" status="danger" :percentage="entity().rage / entity().maxRage * 100">Rage</n-progress>
+-->
       <n-progress v-if="entity().combo > 0" class="circle-stat" type="circle" status="warning" :percentage="entity().combo / entity().maxCombo * 100">Combo</n-progress>
     </span>
 
@@ -80,6 +88,7 @@ function entity () {
   margin-bottom: 5px;
   align-items: center;
   justify-content: space-between;
+  word-break: normal;
 
   .left {
     display: flex;
@@ -109,11 +118,12 @@ function entity () {
       font-size: 10px;
     }
   }
-  // .quick-stats {
-  //   height: 12px;
-  //   // margin-right: 10px;
-  //   // width: 190px;
-  // }
+   .quick-stats {
+    height: 12px;
+    margin-right: 5px;
+    width: 30px;
+   }
+
   // .flex {
   //   display: flex;
   //   flex-direction: row;


### PR DESCRIPTION
**Fixes**

The `Food` text being broken for mercs

**Before**
![image](https://user-images.githubusercontent.com/11844042/236200768-1b33802b-32a7-47b1-823e-ea7c9ec95960.png)
**After**
![image](https://user-images.githubusercontent.com/11844042/236201164-f6f62f59-d340-4bdc-915b-29eb65ca3564.png)

The resource bars being on unequal lengths, depending on how much resource is left
**Before**(notice the stamina bar is smaller than others)
![image](https://user-images.githubusercontent.com/11844042/236201622-3e430544-8c39-4b74-8601-412e9ab58a04.png)
**After**
![image](https://user-images.githubusercontent.com/11844042/236207731-8b79912a-4633-4b8a-b444-1d88bcb0a361.png)

**Changes**

Currently, rage is being showed via a `circle-stat` doughnut. But unless you are actively in and out of large fights, rage will usually stay at pretty low values (around 10). That means that the actual amount of rage available is either barely visible on the `circle-stat` or completely invisible, and the player does not know the exact value of available rage. So I switched it up so that rage shows like the other resources.

**Before**(rage 6, not visible at all on the circle)
![image](https://user-images.githubusercontent.com/11844042/236202869-36c1d596-ea24-4cd3-bdf6-75a9215d5f95.png)
**After** 
![image](https://user-images.githubusercontent.com/11844042/236207147-5b57b760-53d9-4045-8069-7a9eed970384.png)
