### PR TITLE
Added order queue

### DIFF
--- a/src/components/main-area/BattleStatus.vue
+++ b/src/components/main-area/BattleStatus.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="battle-area">
-    <MercOrders></MercOrders>
+    <MercOrders v-if="showOrdersRef"></MercOrders>
     <div class="battle-status">
       <div class="side good">
         <div class="entity" v-for="entity in getSide('good')" :key="entity.name">
@@ -49,7 +49,7 @@
 </template>
 
 <script setup>
-import { onMounted, ref } from 'vue'
+import {onMounted, ref, watch} from 'vue'
 
 import { state } from '@/composables/state'
 
@@ -57,6 +57,7 @@ import BattleEntity from '@/components/main-area/battle-items/BattleEntity.vue'
 import MercOrders from '@/components/main-area/battle-items/MercOrders.vue'
 
 const battleStatus = ref(null)
+const showOrdersRef = ref(false)
 
 function getSide (side) {
   return state.gameState.battle.participants.filter(p => p.side == side)
@@ -71,12 +72,28 @@ function getAnimationClass (anim) {
   return classes.join(' ')
 }
 
+function isMercHere() {
+  let isMercHere = false
+  state.gameState.battle.participants.map(participant => {
+    if (participant.eid === state.gameState.mercEid) {
+      isMercHere = true
+    }
+  })
+  return isMercHere
+}
+
 onMounted(() => {
   let parent = battleStatus.value?.parentElement
+  showOrdersRef.value = isMercHere()
   if (parent) {
     parent.scrollTo(0, parent.scrollHeight)
   }
 })
+
+watch(state.gameState.battle.participants, function () {
+  showOrdersRef.value = isMercHere()
+})
+
 </script>
 
 <style lang="less">

--- a/src/components/main-area/BattleStatus.vue
+++ b/src/components/main-area/BattleStatus.vue
@@ -1,44 +1,47 @@
 <template>
-  <div class="battle-status">
-    <div class="side good">
-      <div class="entity" v-for="entity in getSide('good')" :key="entity.name">
-        <TransitionGroup appear name="damage">
-          <div
-            v-for="anim in state.animations.filter(a => a.eid == entity.eid && a.type == 'damage')"
-            :key="anim.key"
-            :class="getAnimationClass(anim)"
-          >{{ anim.amount }}</div>
-        </TransitionGroup>
-        <TransitionGroup appear name="healing">
-          <div
-            v-for="anim in state.animations.filter(a => a.eid == entity.eid && a.type == 'healing')"
-            :key="anim.key"
-            :class="getAnimationClass(anim)"
-          >{{ anim.amount }}</div>
-        </TransitionGroup>
-        <BattleEntity :entity="entity"></BattleEntity>
+  <div class="battle-area">
+    <MercOrders></MercOrders>
+    <div class="battle-status">
+      <div class="side good">
+        <div class="entity" v-for="entity in getSide('good')" :key="entity.name">
+          <TransitionGroup appear name="damage">
+            <div
+              v-for="anim in state.animations.filter(a => a.eid == entity.eid && a.type == 'damage')"
+              :key="anim.key"
+              :class="getAnimationClass(anim)"
+            >{{ anim.amount }}</div>
+          </TransitionGroup>
+          <TransitionGroup appear name="healing">
+            <div
+              v-for="anim in state.animations.filter(a => a.eid == entity.eid && a.type == 'healing')"
+              :key="anim.key"
+              :class="getAnimationClass(anim)"
+            >{{ anim.amount }}</div>
+          </TransitionGroup>
+          <BattleEntity :entity="entity"></BattleEntity>
+        </div>
       </div>
-    </div>
 
-    <div class="vs">VS</div>
+      <div class="vs">VS</div>
 
-    <div class="side evil">
-      <div class="entity" v-for="entity in getSide('evil')" :key="entity.name">
-        <TransitionGroup appear name="damage">
-          <div
-            v-for="anim in state.animations.filter(a => a.eid == entity.eid && a.type == 'damage')"
-            :key="anim.key"
-            :class="getAnimationClass(anim)"
-          >{{ anim.amount }}</div>
-        </TransitionGroup>
-        <TransitionGroup appear name="healing">
-          <div
-            v-for="anim in state.animations.filter(a => a.eid == entity.eid && a.type == 'healing')"
-            :key="anim.key"
-            :class="getAnimationClass(anim)"
-          >{{ anim.amount }}</div>
-        </TransitionGroup>
-        <BattleEntity :entity="entity"></BattleEntity>
+      <div class="side evil">
+        <div class="entity" v-for="entity in getSide('evil')" :key="entity.name">
+          <TransitionGroup appear name="damage">
+            <div
+              v-for="anim in state.animations.filter(a => a.eid == entity.eid && a.type == 'damage')"
+              :key="anim.key"
+              :class="getAnimationClass(anim)"
+            >{{ anim.amount }}</div>
+          </TransitionGroup>
+          <TransitionGroup appear name="healing">
+            <div
+              v-for="anim in state.animations.filter(a => a.eid == entity.eid && a.type == 'healing')"
+              :key="anim.key"
+              :class="getAnimationClass(anim)"
+            >{{ anim.amount }}</div>
+          </TransitionGroup>
+          <BattleEntity :entity="entity"></BattleEntity>
+        </div>
       </div>
     </div>
   </div>
@@ -51,6 +54,7 @@ import { onMounted, ref } from 'vue'
 import { state } from '@/composables/state'
 
 import BattleEntity from '@/components/main-area/battle-items/BattleEntity.vue'
+import MercOrders from '@/components/main-area/battle-items/MercOrders.vue'
 
 const battleStatus = ref(null)
 
@@ -76,9 +80,14 @@ onMounted(() => {
 </script>
 
 <style lang="less">
+
+.battle-area {
+  margin-top: 5px;
+  border-top: 2px solid #333;
+}
+
 .battle-status {
   display: flex;
-  border-top: 2px solid #333;
   top: 0;
   width: 100%;
   margin-top: 5px;

--- a/src/components/main-area/battle-items/MercOrders.vue
+++ b/src/components/main-area/battle-items/MercOrders.vue
@@ -1,14 +1,13 @@
 <template>
     <div class="order-dropdown">
       <n-dropdown
-        :show="showDropdownRef"
         placement="bottom-start"
         trigger="click"
         size="large"
         :options="options"
         @select="handleSelect"
       >
-        <n-button @click="handleClick">Queue Order</n-button>
+        <n-button>Queue Order</n-button>
       </n-dropdown>
     </div>
 </template>
@@ -16,35 +15,34 @@
 <script setup>
 import { NDropdown, NButton } from 'naive-ui'
 import { helpers } from '@/composables/helpers'
-import { reactive, ref, onMounted } from 'vue'
+import { reactive, onMounted, watch } from 'vue'
 import { useWebSocket } from '@/composables/web_socket'
+import { state } from '@/composables/state'
 
 const { getMerc } = helpers()
 const { fetchItems, cmd } = useWebSocket()
 
 const options = reactive([])
-const showDropdownRef = ref(false)
 
 const combatPotions = ["healing potion", "energy potion", "stamina potion"]
 
 /*
     TODO
 - Have a way to select a target on which the action / skill is performed
+- Add more potions
  */
 
 onMounted(async () => {
     await setOptions()
 })
 
-function handleClick () {
-    setOptions()
-    showDropdownRef.value = !showDropdownRef.value
-}
-
 function handleSelect(order) {
     cmd(`queue ${order}`)
-    showDropdownRef.value = false
 }
+
+watch(() => state.gameState.party, () => {
+    setOptions()
+})
 
 async function setOptions() {
     const merc = getMerc()

--- a/src/components/main-area/battle-items/MercOrders.vue
+++ b/src/components/main-area/battle-items/MercOrders.vue
@@ -1,0 +1,115 @@
+<template>
+    <div class="order-dropdown" v-if="showOrdersRef">
+        <n-dropdown
+          :show="showDropdownRef"
+          placement="bottom-start"
+          trigger="click"
+          size="large"
+          :options="options"
+          @select="handleSelect"
+        >
+            <n-button @click="handleClick">Queue Order</n-button>
+        </n-dropdown>
+    </div>
+</template>
+
+<script setup>
+import { NDropdown } from 'naive-ui'
+import { helpers } from '@/composables/helpers'
+import {reactive, ref, onMounted, watch} from 'vue'
+import { useWebSocket } from '@/composables/web_socket'
+import { state } from '@/composables/state'
+
+const { getMerc } = helpers()
+const { fetchItems, cmd } = useWebSocket()
+
+const options = reactive([])
+const showDropdownRef = ref(false)
+const showOrdersRef = ref(false)
+
+const combatPotions = ["healing potion", "energy potion", "stamina potion"]
+
+/*
+    TODO
+- Have a way to select a target on which the action / skill is performed
+ */
+
+onMounted(async () => {
+    await setOptions()
+    showOrdersRef.value = isMercHere()
+})
+
+watch(state.gameState.battle.participants, function () {
+    setOptions()
+    showOrdersRef.value = isMercHere()
+})
+
+function handleClick () {
+    showDropdownRef.value = !showDropdownRef.value
+    setOptions()
+}
+
+function handleSelect(order) {
+    cmd(`queue ${order}`)
+    showDropdownRef.value = !showDropdownRef.value
+}
+
+function isMercHere() {
+    let isMercHere = false
+    state.gameState.battle.participants.map(participant => {
+        if (participant.eid === state.gameState.mercEid) {
+            isMercHere = true
+        }
+    })
+    return isMercHere
+}
+
+async function setOptions() {
+    const merc = getMerc()
+    const divider = {
+        type: 'divider',
+        key: 'd1'
+    }
+    options.length = 0
+    if (merc) {
+        const mercSkills = merc.skills.filter(skill => !skill.type.includes('passive'))
+        // The regex fresh hell below is to capitalize first letter for each word in the skill list
+        // Ideally, we'd just use CSS' text-transform: capitalize; for this, but naiveUI makes it a pain to target the
+        // elements in the dropdown. Will have to revisit this
+        mercSkills.map(skill => options.push({
+            label: skill.name.replace(/(^\w{1})|(\s+\w{1})/g, letter => letter.toUpperCase()),
+            key: `eid:${merc.stats.eid.toString()} ${skill.name}`
+        }))
+
+        const items = await fetchItems(merc.items);
+
+        items.map(item => {
+            const itemName = item.name.substring(item.name.indexOf(" ") + 1).toLowerCase()
+            if (combatPotions.includes(itemName)) {
+
+                if (!options.includes(divider)) {
+                    options.push(divider)
+                }
+
+                const itemType = itemName.substring(0, itemName.indexOf(" "))
+                  .replace(/(^\w{1})|(\s+\w{1})/g, letter => letter.toUpperCase())
+
+                options.push({
+                    label: `Drink ${itemType}`,
+                    key: `eid:${merc.stats.eid.toString()} drink ${itemName.substring(0, itemName.indexOf(" "))}`
+                })
+            }
+        })
+    }
+}
+
+</script>
+
+<style lang="less" scoped>
+.order-dropdown {
+    font-size: 16px;
+    margin-top: 5px;
+    cursor: pointer;
+    text-decoration: underline;
+}
+</style>

--- a/src/components/main-area/battle-items/MercOrders.vue
+++ b/src/components/main-area/battle-items/MercOrders.vue
@@ -1,31 +1,29 @@
 <template>
-    <div class="order-dropdown" v-if="showOrdersRef">
-        <n-dropdown
-          :show="showDropdownRef"
-          placement="bottom-start"
-          trigger="click"
-          size="large"
-          :options="options"
-          @select="handleSelect"
-        >
-            <n-button @click="handleClick">Queue Order</n-button>
-        </n-dropdown>
+    <div class="order-dropdown">
+      <n-dropdown
+        :show="showDropdownRef"
+        placement="bottom-start"
+        trigger="click"
+        size="large"
+        :options="options"
+        @select="handleSelect"
+      >
+        <n-button @click="handleClick">Queue Order</n-button>
+      </n-dropdown>
     </div>
 </template>
 
 <script setup>
-import { NDropdown } from 'naive-ui'
+import { NDropdown, NButton } from 'naive-ui'
 import { helpers } from '@/composables/helpers'
-import {reactive, ref, onMounted, watch} from 'vue'
+import { reactive, ref, onMounted } from 'vue'
 import { useWebSocket } from '@/composables/web_socket'
-import { state } from '@/composables/state'
 
 const { getMerc } = helpers()
 const { fetchItems, cmd } = useWebSocket()
 
 const options = reactive([])
 const showDropdownRef = ref(false)
-const showOrdersRef = ref(false)
 
 const combatPotions = ["healing potion", "energy potion", "stamina potion"]
 
@@ -36,32 +34,16 @@ const combatPotions = ["healing potion", "energy potion", "stamina potion"]
 
 onMounted(async () => {
     await setOptions()
-    showOrdersRef.value = isMercHere()
-})
-
-watch(state.gameState.battle.participants, function () {
-    setOptions()
-    showOrdersRef.value = isMercHere()
 })
 
 function handleClick () {
-    showDropdownRef.value = !showDropdownRef.value
     setOptions()
+    showDropdownRef.value = !showDropdownRef.value
 }
 
 function handleSelect(order) {
     cmd(`queue ${order}`)
-    showDropdownRef.value = !showDropdownRef.value
-}
-
-function isMercHere() {
-    let isMercHere = false
-    state.gameState.battle.participants.map(participant => {
-        if (participant.eid === state.gameState.mercEid) {
-            isMercHere = true
-        }
-    })
-    return isMercHere
+    showDropdownRef.value = false
 }
 
 async function setOptions() {
@@ -107,9 +89,6 @@ async function setOptions() {
 
 <style lang="less" scoped>
 .order-dropdown {
-    font-size: 16px;
-    margin-top: 5px;
-    cursor: pointer;
-    text-decoration: underline;
+  margin-top: 5px;
 }
 </style>

--- a/src/components/modals/MercModal.vue
+++ b/src/components/modals/MercModal.vue
@@ -57,7 +57,7 @@ import { helpers } from '@/composables/helpers'
 
 import QuickStats from '@/components/side-menu/QuickStats'
 
-const { ansiToHtml } = helpers()
+const { ansiToHtml, getMerc } = helpers()
 
 const mercVitals = ref({})
 const mercEntity = ref({})
@@ -83,15 +83,13 @@ function closeModal() {
 }
 
 async function findAndSetMerc() {
-  let merc = Object.values(state.gameState.charmies)
-    .find(charmie => charmie && charmie.traits && charmie.traits.includes('mercenary'))
-  if (!merc) {
-    state.gameState.mercEid = -1
-    return
-  }
+  const merc = getMerc()
 
-  mercEntity.value = merc.stats
+  if (!merc) {
+      return
+  }
   state.gameState.mercEid = merc.stats.eid
+  mercEntity.value = merc.stats
   mercVitals.value = merc.stats
   mercSkills.value = merc.skills
   mercInventory.value = merc.items

--- a/src/composables/helpers.js
+++ b/src/composables/helpers.js
@@ -1,8 +1,25 @@
+import { state } from "@/composables/state";
+import { action_mapper } from '@/composables/constants/action_mapper';
+
 const AU = require('ansi_up')
 const ansi_up = new AU.default
 ansi_up.use_classes = true
-
-import { action_mapper } from '@/composables/constants/action_mapper';
+const ansi = {
+    boldBlack: String.fromCharCode(27) + '[90m',
+    boldRed: String.fromCharCode(27) + '[91m',
+    boldWhite: String.fromCharCode(27) + '[97m',
+    reset: String.fromCharCode(27) + '[0m'
+}
+const replacements = [
+    { from: '1;30m', to: '90m' },
+    { from: '1;31m', to: '91m' },
+    { from: '1;32m', to: '92m' },
+    { from: '1;33m', to: '93m' },
+    { from: '1;34m', to: '94m' },
+    { from: '1;35m', to: '95m' },
+    { from: '1;36m', to: '96m' },
+    { from: '1;37m', to: '97m' },
+]
 
 export function helpers() {
     function copperToMoneyString(amount, short) {
@@ -50,24 +67,6 @@ export function helpers() {
         return isPlayer ? playerActions : mercActions;
     }
 
-    const ansi = {
-        boldBlack: String.fromCharCode(27) + '[90m',
-        boldRed: String.fromCharCode(27) + '[91m',
-        boldWhite: String.fromCharCode(27) + '[97m',
-        reset: String.fromCharCode(27) + '[0m'
-    }
-
-    const replacements = [
-        { from: '1;30m', to: '90m' },
-        { from: '1;31m', to: '91m' },
-        { from: '1;32m', to: '92m' },
-        { from: '1;33m', to: '93m' },
-        { from: '1;34m', to: '94m' },
-        { from: '1;35m', to: '95m' },
-        { from: '1;36m', to: '96m' },
-        { from: '1;37m', to: '97m' },
-    ]
-
     function ansiToHtml (str) {
         for (let { from, to } of replacements) {
             str = str.replace(new RegExp(from, 'g'), to)
@@ -75,5 +74,16 @@ export function helpers() {
         return ansi_up.ansi_to_html(str)
     }
 
-    return { copperToMoneyString, getActions, ansiToHtml, ansi }
+    function getMerc() {
+        const merc = Object.values(state.gameState.charmies)
+            .find(charmie => charmie && charmie.traits && charmie.traits.includes('mercenary'))
+        if (!merc) {
+            state.gameState.mercEid = -1
+            return false
+        }
+        state.gameState.mercEid = merc.stats.eid
+        return merc
+    }
+
+    return { copperToMoneyString, getActions, ansiToHtml, getMerc, ansi }
 }


### PR DESCRIPTION
Added a basic order queue dropdown. Tracking of what is queued and selecting target for the queued skill will be done at some later point. 

![image](https://github.com/dinchak/procrealms-web-client/assets/11844042/488b3160-1787-4e0c-9f0f-b9e4c9199a60)

Wish list for future iterations:

- Have a clear way to track which action is queued. Right now, the base message of the queue order is still shown, so not including this right now does not take away any information
- Allow target selection for skills
- Add more potions to the list of actions
