### PR TITLE
Adds Cmd-1/2/3/4 keyboard shortcuts for chat tabs

### DIFF
--- a/src/components/main-area/LineOutput.vue
+++ b/src/components/main-area/LineOutput.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <n-tabs class="tabs" @before-leave="onBeforeChangeTab" @update:value="onAfterChangeTab" :bar-width="20">
+  <n-tabs class="tabs" ref="tabsInstance" v-model:value="currentPane" @before-leave="onBeforeChangeTab" @update:value="onAfterChangeTab" :bar-width="20">
     <n-tab-pane name="output" tab="Main" display-directive="show">
       <div id="output" :class="getOutputClass()" ref="output" @scroll="onScroll('output')">
         <div v-for="(line, i) in state.output" class="line" v-html-safe="line" :key="`line-${i}`"></div>
@@ -75,6 +75,7 @@ import { ref, watch, nextTick, onMounted, h } from 'vue'
 import { state } from '@/composables/state'
 import { useWebSocket } from '@/composables/web_socket'
 import { useWindowHandler } from '@/composables/window_handler'
+import { useKeyHandler } from '@/composables/key_handler'
 
 import BattleStatus from '@/components/main-area/BattleStatus.vue'
 
@@ -87,11 +88,52 @@ const output = ref(null)
 const chat = ref(null)
 const trade = ref(null)
 const newbie = ref(null)
+const tabsInstance = ref(null)
+const currentPane = ref("output") // chat, trade, or newbie
 
 const refs = { output, chat, trade, newbie }
 
 const { send } = useWebSocket()
 const { onResize, calcTerminalSize } = useWindowHandler()
+
+// Keyboard Shortcuts
+const { onKeydown, keyState } = useKeyHandler()
+onKeydown((ev) => {
+  // Switch to Main
+  if (keyState.ctrl && ev.code =='Digit1') {
+    onBeforeChangeTab(currentPane.value)
+    currentPane.value = "output"
+    state.activeTab = "output"
+    nextTick(() => tabsInstance.value?.syncBarPosition());
+    return true
+  } 
+  // Switch to Chat
+  else if (keyState.ctrl && ev.code =='Digit2') {
+    onBeforeChangeTab(currentPane.value)
+    currentPane.value = "chat"
+    state.activeTab = "chat"
+    nextTick(() => tabsInstance.value?.syncBarPosition());
+    return true
+  }
+  // Switch to Trade
+  else if (keyState.ctrl && ev.code =='Digit3') {
+    onBeforeChangeTab(currentPane.value)
+    currentPane.value = "trade"
+    state.activeTab = "trade"
+    nextTick(() => tabsInstance.value?.syncBarPosition());
+    return true
+  }
+  // Switch to Newbie
+  else if (keyState.ctrl && ev.code =='Digit4') {
+    onBeforeChangeTab(currentPane.value)
+    currentPane.value = "newbie"
+    state.activeTab = "newbie"
+    nextTick(() => tabsInstance.value?.syncBarPosition());
+    return true
+  }
+
+  return false
+})
 
 onResize(doResize)
 

--- a/src/composables/key_handler.js
+++ b/src/composables/key_handler.js
@@ -13,7 +13,7 @@ export function useKeyHandler () {
   let handlerAttached = false
 
   function handleMetaKey (key, state) {
-    if (key == 'Control') {
+    if (key == 'Control' || key == 'Meta') {
       keyState.ctrl = state
       return true
     }


### PR DESCRIPTION
A simple quality of life feature. The game is almost entirely played on a keyboard except for when I need to switch tabs for the various chat windows. This should make it much easier to do so. Just use Cmd-2 (Mac) or Ctrl-2 (Windows) to switch to the chat window. Cmd-1 switches back to Main.