### PR TITLE
Add additional map sizes

### DIFF
--- a/src/components/main-area/LineOutput.vue
+++ b/src/components/main-area/LineOutput.vue
@@ -90,6 +90,7 @@ const trade = ref(null)
 const newbie = ref(null)
 const tabsInstance = ref(null)
 const currentPane = ref("output") // chat, trade, or newbie
+var mapWasOpen = false
 
 const refs = { output, chat, trade, newbie }
 
@@ -197,6 +198,11 @@ function onBeforeChangeTab (activeName) {
     state[activeName].forEach(msg => msg.unread = false)
   }
   state.activeTab = activeName
+  // Hide Map Modal on chat tabs
+  if (activeName !== "output" && state.modals.mapModal == true) {
+    mapWasOpen = true
+    state.modals.mapModal = false
+  }
   return true
 }
 
@@ -204,6 +210,11 @@ function onAfterChangeTab (activeName) {
   setTimeout(() => {
     scrollDown(activeName)
   })
+  // Show Map Modal on output tab if it was open before
+  if (activeName == "output" && mapWasOpen == true) {
+    mapWasOpen = false
+    state.modals.mapModal = true
+  }
 }
 
 function getTab (name) {

--- a/src/components/modals/MapModal.vue
+++ b/src/components/modals/MapModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <n-card title="Map" size="small" :class="[getSideClass(), geMapModalSizeClass()]" v-if="state.modals.mapModal" content-style="display: flex; flex-wrap: wrap; justify-content: center; align-content:center; overflow:hidden;" closable @close="closeModal()">
+  <n-card title="Map" size="small" :class="['right', geMapModalSizeClass()]" v-if="state.modals.mapModal" content-style="display: flex; flex-wrap: wrap; justify-content: center; align-content:center; overflow:hidden;" closable @close="closeModal()">
     <template #header-extra>
       <n-button text @click="toggleMapModalSize()">
         <n-icon size="15"><WindowOutlined></WindowOutlined></n-icon>
@@ -64,9 +64,9 @@ function geMapModalSizeClass() {
   return "map-" + state.modals.mapModalSize
 }
 
-function getSideClass() {
-  return state.options.swapControls ? 'map-modal right' : 'map-modal left'
-}
+// function getSideClass() {
+//   return state.options.swapControls ? 'map-modal right' : 'map-modal left'
+// }
 
 function closeModal() {
   state.modals.mapModal = false
@@ -102,12 +102,8 @@ onMounted(() => {
   line-height: 13px;
 }
 
-.left {
-  right: 10px;
-}
-
 .right {
-  left: 10px;
+  right: 10px;
 }
 
 .n-card {

--- a/src/components/modals/MapModal.vue
+++ b/src/components/modals/MapModal.vue
@@ -124,7 +124,6 @@ onMounted(() => {
 
 .n-card.map-medium {
   width: 600px;
-  height: 600px;
 }
 
 .close {

--- a/src/components/modals/MapModal.vue
+++ b/src/components/modals/MapModal.vue
@@ -1,18 +1,23 @@
 <template>
-  <n-card :class="getSideClass()" v-if="state.modals.mapModal">
-    <p class="close" v-on:click="closeModal()">x</p>
+  <n-card title="Map" size="small" :class="[getSideClass(), geMapModalSizeClass()]" v-if="state.modals.mapModal" content-style="display: flex; flex-wrap: wrap; justify-content: center; align-content:center; overflow:hidden;" closable @close="closeModal()">
+    <template #header-extra>
+      <n-button text @click="toggleMapModalSize()">
+        <n-icon size="15"><WindowOutlined></WindowOutlined></n-icon>
+      </n-button>
+    </template>
     <div class="ansi" v-for="(line, id) in largeMap" :key="id" v-html-safe="ansiToHtml(line)"></div>
   </n-card>
 </template>
 
 <script setup>
-import { NCard } from 'naive-ui'
+import { NCard, NButton, NIcon } from 'naive-ui'
 import { ref, watch, onMounted } from 'vue'
 import { helpers } from '@/composables/helpers'
 import { state } from '@/composables/state'
 import { command_ids } from '@/composables/constants/command_ids'
 import { useWebSocket } from '@/composables/web_socket'
 import { useKeyHandler } from '@/composables/key_handler'
+import WindowOutlined from '@vicons/material/WindowOutlined'
 
 const { cmd } = useWebSocket()
 const { onKeydown, keyState } = useKeyHandler()
@@ -42,6 +47,22 @@ watch(() => state.gameState.map, () => {
     cmd('map', MAP_ID)
   }
 })
+
+function toggleMapModalSize() {
+  if (state.modals.mapModalSize == "small") {
+    state.modals.mapModalSize = "medium"
+  }
+  else if (state.modals.mapModalSize == "medium") {
+    state.modals.mapModalSize = "large"
+  }
+  else {
+    state.modals.mapModalSize = "small"
+  }
+}
+
+function geMapModalSizeClass() {
+  return "map-" + state.modals.mapModalSize
+}
 
 function getSideClass() {
   return state.options.swapControls ? 'map-modal right' : 'map-modal left'
@@ -77,23 +98,33 @@ onMounted(() => {
 .ansi {
   font-family: 'Inconsolata', monospace;
   white-space: pre;
-  font-size: 13px;
+  font-size: 16px;
   line-height: 13px;
 }
 
 .left {
-  left: 5px;
+  right: 10px;
 }
 
 .right {
-  right: 5px;
+  left: 10px;
 }
 
 .n-card {
   position: absolute;
   margin-top: 35px;
-  max-width: calc(100vw - 310px);
+  max-width: calc(100vw - 290px);
   z-index: 2;
+}
+
+.n-card.map-small {
+  width: 400px;
+  height: 400px;
+}
+
+.n-card.map-medium {
+  width: 600px;
+  height: 600px;
 }
 
 .close {

--- a/src/composables/state.js
+++ b/src/composables/state.js
@@ -51,6 +51,7 @@ export const state = reactive({
       mercItemModal: ref('')
     },
     mapModal: false,
+    mapModalSize: 'large',
     mercModal: false
   }
 })


### PR DESCRIPTION
The map modal is really convenient but takes up 90% of the line output screen real estate. This adds 2 more size options for the map modal to customize the mapping experience. They are toggleable via the window button next to the map modal close button (see screenshot below).

Some other related updates:
* Upped the font-size of the default map so that it is consistent with the font-size set with the rest of the app
* Map modal now hides when viewing any of the chat tabs and unhides when going back to output

I'm still trying to decide the best way to store the `mapModalSize` option. Right now it defaults to 'large' and you can change it with every new session. It might be better to store the chosen size under `state.options`, but might complicate things a bit. 

Gonna keep play testing to see how I feel. Let me know what you think.

![CleanShot 2023-08-07 at 13 36 12](https://github.com/dinchak/procrealms-web-client/assets/3942955/314aa56f-d90c-48db-892e-dc165fd8a890)
