### PR TITLE
Add triggers & variables (Round 2)

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-VUE_APP_WEBSOCKET_URL=wss://play.proceduralrealms.com/ws
-VUE_APP_TITLE=Procedural Realms
+VUE_APP_WEBSOCKET_URL=ws://172.29.242.142:8001
+VUE_APP_TITLE=Dev - Procedural Realms

--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-VUE_APP_WEBSOCKET_URL=ws://172.29.242.142:8001
+VUE_APP_WEBSOCKET_URL=wss://play.proceduralrealms.com/ws
 VUE_APP_TITLE=Dev - Procedural Realms

--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-VUE_APP_WEBSOCKET_URL=ws://172.29.242.142:8001
-VUE_APP_TITLE=Dev - Procedural Realms
+VUE_APP_WEBSOCKET_URL=wss://play.proceduralrealms.com/ws
+VUE_APP_TITLE=Procedural Realms

--- a/src/components/main-area/KeyboardInput.vue
+++ b/src/components/main-area/KeyboardInput.vue
@@ -131,67 +131,73 @@ onKeydown((ev) => {
     return false
   }
 
-  if (ev.key == 'Enter' && state.mode == 'input') {
-    if (!input.value.value) {
+  if (state.mode == 'input') {
+
+    if (ev.key == 'Enter') {
+      if (!input.value.value) {
+        input.value.blur()
+        return true
+      }
+      sendCommand()
+      return true
+    }
+
+    if (ev.code == 'Escape') {
       input.value.blur()
       return true
     }
-    sendCommand()
-    return true
+
+    if (ev.code == 'ArrowUp') {
+      prevCommand()
+      return true
+    }
+
+    if (ev.code == 'ArrowDown') {
+      nextCommand()
+      return true
+    }
+  }
+
+  if(state.mode == 'input' || !state.modals.triggersModal) {
+
+    if (ev.key == 'PageUp') {
+      let activeTabElement = document.getElementById(state.activeTab)
+      activeTabElement.scrollTo(0, activeTabElement.scrollTop - activeTabElement.clientHeight * 9 / 10)
+      return true
+    }
+
+    if (ev.key == 'PageDown') {
+      let activeTabElement = document.getElementById(state.activeTab)
+      activeTabElement.scrollTo(0, activeTabElement.scrollTop + activeTabElement.clientHeight * 9 / 10)
+      return true
+    }
+
+    if (ev.key == 'End') {
+      let activeTabElement = document.getElementById(state.activeTab)
+      if (activeTabElement) {
+        activeTabElement.scrollTo(0, activeTabElement.scrollHeight)
+      }
+      return true
+    }
   }
 
   if (state.modals.triggersModal) {
     return false
   }
 
-  // TODO: handle keyboard focus
-  if (ev.key == 'Enter' && state.mode == 'hotkey') {
-    input.value.focus()
-    return true
-  }
-
-  if (ev.code == 'Escape' && state.mode == 'input') {
-    input.value.blur()
-    return true
-  }
-
-  if (ev.code == 'ArrowUp') {
-    prevCommand()
-    return true
-  }
-
-  if (ev.code == 'ArrowDown') {
-    nextCommand()
-    return true
-  }
-
-  if (ev.key == '?' && state.mode == 'hotkey') {
-    state.showHelp = true
-    return true
-  }
-
-  if (ev.key == 'PageUp') {
-    let activeTabElement = document.getElementById(state.activeTab)
-    activeTabElement.scrollTo(0, activeTabElement.scrollTop - activeTabElement.clientHeight * 9 / 10)
-    return true
-  }
-
-  if (ev.key == 'PageDown') {
-    let activeTabElement = document.getElementById(state.activeTab)
-    activeTabElement.scrollTo(0, activeTabElement.scrollTop + activeTabElement.clientHeight * 9 / 10)
-    return true
-  }
-
-  if (ev.key == 'End') {
-    let activeTabElement = document.getElementById(state.activeTab)
-    if (activeTabElement) {
-      activeTabElement.scrollTo(0, activeTabElement.scrollHeight)
-    }
-    return true
-  }
-
   if (state.mode == 'hotkey') {
-    const { slots } = state.gameState
+
+    if (ev.key == 'Enter') {
+      input.value.focus()
+      return true
+    }
+
+    if (ev.key == '?') {
+      state.showHelp = true
+      return true
+    }
+
+    const {slots} = state.gameState
     let slot = slots.find(s => s.slot == ev.key)
     if (slot) {
       cmd(slot.slot)

--- a/src/components/main-area/KeyboardInput.vue
+++ b/src/components/main-area/KeyboardInput.vue
@@ -144,6 +144,7 @@ onKeydown((ev) => {
     return false
   }
 
+  // TODO: handle keyboard focus
   if (ev.key == 'Enter' && state.mode == 'hotkey') {
     input.value.focus()
     return true

--- a/src/components/main-area/KeyboardInput.vue
+++ b/src/components/main-area/KeyboardInput.vue
@@ -131,6 +131,10 @@ onKeydown((ev) => {
     return false
   }
 
+  if (state.modals.triggersModal) {
+    return false
+  }
+
   if (ev.key == 'Enter' && state.mode == 'hotkey') {
     input.value.focus()
     return true

--- a/src/components/main-area/KeyboardInput.vue
+++ b/src/components/main-area/KeyboardInput.vue
@@ -131,6 +131,15 @@ onKeydown((ev) => {
     return false
   }
 
+  if (ev.key == 'Enter' && state.mode == 'input') {
+    if (!input.value.value) {
+      input.value.blur()
+      return true
+    }
+    sendCommand()
+    return true
+  }
+
   if (state.modals.triggersModal) {
     return false
   }
@@ -152,15 +161,6 @@ onKeydown((ev) => {
 
   if (ev.code == 'ArrowDown') {
     nextCommand()
-    return true
-  }
-
-  if (ev.key == 'Enter' && state.mode == 'input') {
-    if (!input.value.value) {
-      input.value.blur()
-      return true
-    }
-    sendCommand()
     return true
   }
 

--- a/src/components/modals/LoginModal.vue
+++ b/src/components/modals/LoginModal.vue
@@ -38,6 +38,7 @@ import { NModal, NForm, NFormItem, NInput, NButton } from 'naive-ui'
 import { state } from '@/composables/state'
 
 import { useWebSocket } from '@/composables/web_socket'
+import { loadTriggers } from "@/composables/triggers";
 const { send } = useWebSocket()
 
 const formRef = ref(null)
@@ -78,6 +79,7 @@ const rules = {
         return new Promise((resolve, reject) => {
           state.loginResolve = resolve
           state.loginReject = reject
+          loadTriggers(model.value.name)
           send('login', { name: model.value.name, password: model.value.password, width: 80, height: 24, ttype: 'play.proceduralrealms.com' })
         })
       }

--- a/src/components/modals/LoginModal.vue
+++ b/src/components/modals/LoginModal.vue
@@ -38,7 +38,7 @@ import { NModal, NForm, NFormItem, NInput, NButton } from 'naive-ui'
 import { state } from '@/composables/state'
 
 import { useWebSocket } from '@/composables/web_socket'
-import { loadTriggers } from "@/composables/triggers"
+import { loadSettingsByNameAndType } from "@/composables/triggers"
 
 const { send } = useWebSocket()
 
@@ -80,7 +80,8 @@ const rules = {
         return new Promise((resolve, reject) => {
           state.loginResolve = resolve
           state.loginReject = reject
-          loadTriggers(model.value.name)
+          loadSettingsByNameAndType(state.triggers, model.value.name, 'triggers')
+          loadSettingsByNameAndType(state.variables, model.value.name, 'variables')
           send('login', { name: model.value.name, password: model.value.password, width: 80, height: 24, ttype: 'play.proceduralrealms.com' })
         })
       }

--- a/src/components/modals/LoginModal.vue
+++ b/src/components/modals/LoginModal.vue
@@ -38,7 +38,7 @@ import { NModal, NForm, NFormItem, NInput, NButton } from 'naive-ui'
 import { state } from '@/composables/state'
 
 import { useWebSocket } from '@/composables/web_socket'
-import { loadTriggers } from "@/composables/triggers";
+import { loadTriggers } from "@/composables/triggers"
 const { send } = useWebSocket()
 
 const formRef = ref(null)

--- a/src/components/modals/LoginModal.vue
+++ b/src/components/modals/LoginModal.vue
@@ -39,6 +39,7 @@ import { state } from '@/composables/state'
 
 import { useWebSocket } from '@/composables/web_socket'
 import { loadTriggers } from "@/composables/triggers"
+
 const { send } = useWebSocket()
 
 const formRef = ref(null)

--- a/src/components/modals/MapModal.vue
+++ b/src/components/modals/MapModal.vue
@@ -56,11 +56,15 @@ onKeydown((ev) => {
     return false
   }
 
+  if (state.modals.triggersModal) {
+    return false
+  }
+
   if (state.mode === 'input') {
     return false
   }
 
-  if (ev.key === 'M' || ev.key === 'm') {
+  if (ev.code === 'KeyM') {
     state.modals.mapModal = !state.modals.mapModal
     return true
   }

--- a/src/components/modals/TriggersModal.vue
+++ b/src/components/modals/TriggersModal.vue
@@ -165,7 +165,7 @@ const updateSelectedVariableKeys = (keys) => {
 }
 
 function onlyAlphaNumericMax50(value) {
-  return /^[a-zA-Z][a-zA-Z0-9]{1,50}$/.test(value)
+  return /^[a-zA-Z][a-zA-Z0-9]{0,50}$/.test(value) || !value
 }
 
 function changeTriggerShared(shared) {

--- a/src/components/modals/TriggersModal.vue
+++ b/src/components/modals/TriggersModal.vue
@@ -301,7 +301,7 @@ window.onstorage = (event) => {
 .n-card {
   position: absolute;
   margin-top: 125px;
-  max-width: calc(100vw - 610px);
+  max-width: calc(100vw - 290px);
   z-index: 3;
 }
 
@@ -323,11 +323,11 @@ window.onstorage = (event) => {
 }
 
 .triggers-modal-left {
-  left: 45px
+  left: 8px
 }
 
 .triggers-modal-right {
-  right: 45px;
+  right: 8px;
 }
 
 .close {

--- a/src/components/modals/TriggersModal.vue
+++ b/src/components/modals/TriggersModal.vue
@@ -159,13 +159,13 @@ const updateSelectedVariableKeys = (keys) => {
     let variable = state.variables.value.get(key)
     variableModel.value.key = key
     variableModel.value.name = variable.name
-    variableModel.value.values = variable.values
+    variableModel.value.values = variable.values.join('\n')
     variableModel.value.shared = variable.shared
   }
 }
 
 function onlyAlphaNumericMax50(value) {
-  return /^[a-zA-Z0-9]{0,50}$/.test(value)
+  return /^[a-zA-Z][a-zA-Z0-9]{1,50}$/.test(value)
 }
 
 function changeTriggerShared(shared) {

--- a/src/components/modals/TriggersModal.vue
+++ b/src/components/modals/TriggersModal.vue
@@ -84,7 +84,6 @@ function onlyAlphaNumericMax50(value) {
 }
 
 onKeydown((ev) => {
-  // TODO: proper handling of keyboard focus between modal and main input field
   if (keyState.alt || keyState.ctrl) {
     return false
   }
@@ -133,7 +132,7 @@ function updateTriggerList() {
   defaultCheckedKeys.value = []
 
   state.triggers.value.forEach((trigger, id) => {
-    data.value.push({ key: "" + id, label: `(${id}) ${trigger.name}`})
+    data.value.push({ key: "" + id, label: trigger.name})
     if (trigger.active) {
       defaultCheckedKeys.value.push("" + id)
     }

--- a/src/components/modals/TriggersModal.vue
+++ b/src/components/modals/TriggersModal.vue
@@ -50,7 +50,7 @@
         <n-form-item path="commands" label="Commands">
           <n-scrollbar>
             <n-input v-model:value="triggerModel.commands" :disabled="triggerModel.key < 1" type="textarea"
-                     placeholder="Commands to send to the server. Use $1, $2, $3, ... for captured values."/>
+                     placeholder="Commands to send to the server. Use $1, $2, $3, ... for captured values. Use $MyVar for variables. Use $MyVar[0], $MyVar[1], $MyVar[2], ... for variables with multiple values."/>
           </n-scrollbar>
         </n-form-item>
       </n-grid-item>

--- a/src/components/modals/TriggersModal.vue
+++ b/src/components/modals/TriggersModal.vue
@@ -60,11 +60,11 @@
 </template>
 
 <script setup>
-import {NButton, NCard, NFormItem, NGrid, NGridItem, NInput, NScrollbar, NSwitch, NTree} from 'naive-ui'
-import {state} from '@/composables/state'
-import {useKeyHandler} from '@/composables/key_handler'
-import {onMounted, ref} from "vue"
-import {storeTriggers} from "@/composables/triggers"
+import { NButton, NCard, NFormItem, NGrid, NGridItem, NInput, NScrollbar, NSwitch, NTree } from 'naive-ui'
+import { state } from '@/composables/state'
+import { useKeyHandler } from '@/composables/key_handler'
+import { onMounted, ref } from "vue"
+import { getNextId, storeTriggers } from "@/composables/triggers"
 
 const { onKeydown, keyState } = useKeyHandler()
 
@@ -129,11 +129,10 @@ onKeydown((ev) => {
 })
 
 function newTrigger() {
-  let idsAsNumbers = [...state.triggers.value.keys()].map(k => Number(k));
-  let id = 1 + (state.triggers.value.size ? Math.max(...idsAsNumbers) : 0) + '';
+  let id = getNextId()
   model.value = { id: id, name: 'NewTrigger', pattern: null, commands: null, active: false, shared: false }
   state.triggers.value.set(id, { name: 'NewTrigger', pattern: null, commands: null, active: false, shared: false })
-  updateTriggerList()
+  updateTriggerTree()
   storeTriggers()
 }
 
@@ -145,7 +144,7 @@ function saveTrigger(e) {
     trigger.pattern = model.value.pattern
     trigger.commands = model.value.commands
     trigger.shared = model.value.shared
-    updateTriggerList()
+    updateTriggerTree()
     storeTriggers()
   }
 }
@@ -153,11 +152,11 @@ function saveTrigger(e) {
 function deleteTrigger(id) {
   state.triggers.value.delete(id)
   model.value = { id: '-1', name: "", pattern: "", commands: "", active: false, shared: false }
-  updateTriggerList()
+  updateTriggerTree()
   storeTriggers()
 }
 
-function updateTriggerList() {
+function updateTriggerTree() {
   data.value = []
   checkedKeys.value = []
 
@@ -172,7 +171,7 @@ function updateTriggerList() {
 }
 
 onMounted(() => {
-  updateTriggerList()
+  updateTriggerTree()
   selectedKeys.value = []
 })
 

--- a/src/components/modals/TriggersModal.vue
+++ b/src/components/modals/TriggersModal.vue
@@ -2,106 +2,121 @@
   <n-card :class="getSideClass()" v-if="state.modals.triggersModal">
     <p class="close" v-on:click="state.modals.triggersModal = false ">x</p>
 
-    <n-grid :cols="5" :x-gap="12">
+    <n-grid cols="3 1100:5" :x-gap="12" :y-gap="20">
+
+      <!-- Triggers section: -->
       <n-grid-item :span="3">
-        <h3>Triggers</h3>
-        <hr style="margin-bottom: 12px"/>
-      </n-grid-item>
-      <n-grid-item :span="2">
-        <h3>Variables</h3>
-        <hr/>
-      </n-grid-item>
-
-      <n-grid-item>
-        <n-tree
-            block-line
-            checkable
-            virtual-scroll
-            :data="triggerTreeData"
-            :checked-keys="checkedTriggerKeys"
-            :selected-keys="selectedTriggerKeys"
-            @update:checked-keys="updateCheckedTriggerKeys"
-            @update:selected-keys="updateSelectedTriggerKeys"
-        />
-      </n-grid-item>
-
-      <n-grid-item :span="2">
-        <n-grid :cols="2" :x-gap="12">
+        <n-grid :cols="3" :x-gap="12">
+          <n-grid-item :span="3">
+            <h3>Triggers</h3>
+            <hr style="margin-bottom: 12px"/>
+          </n-grid-item>
           <n-grid-item>
-            <n-form-item path="trigger-name" label="Name">
-              <n-input v-model:value="triggerModel.name" :disabled="triggerModel.key < 1" :allow-input="onlyAlphaNumericMax50"
-                       placeholder="Trigger name"/>
+            <n-tree
+                block-line
+                checkable
+                virtual-scroll
+                :data="triggerTreeData"
+                :checked-keys="checkedTriggerKeys"
+                :selected-keys="selectedTriggerKeys"
+                @update:checked-keys="updateCheckedTriggerKeys"
+                @update:selected-keys="updateSelectedTriggerKeys"
+            />
+          </n-grid-item>
+
+          <n-grid-item :span="2">
+            <n-grid :cols="2" :x-gap="12">
+              <n-grid-item>
+                <n-form-item path="trigger-name" label="Name">
+                  <n-input v-model:value="triggerModel.name" :disabled="triggerModel.key < 1"
+                           :allow-input="onlyAlphaNumericMax50"
+                           placeholder="Trigger name"/>
+                </n-form-item>
+              </n-grid-item>
+              <n-grid-item>
+                <n-switch class="triggerSharedSwitch" v-model:value="triggerModel.shared"
+                          :disabled="triggerModel.key < 1" aria-label="Shared" @update:value="changeTriggerShared">
+                  <template #checked>
+                    Shared across characters
+                  </template>
+                  <template #unchecked>
+                    {{ state.name }}'s trigger
+                  </template>
+                </n-switch>
+              </n-grid-item>
+            </n-grid>
+            <n-form-item path="pattern" label="Pattern">
+              <n-input v-model:value="triggerModel.pattern" :disabled="triggerModel.key < 1"
+                       placeholder="RegEx pattern (JavaScript)"/>
+            </n-form-item>
+            <n-form-item path="commands" label="Commands">
+              <n-scrollbar>
+                <n-input v-model:value="triggerModel.commands" :disabled="triggerModel.key < 1" type="textarea"
+                         placeholder="Commands to send to the server. Use $1, $2, $3, ... for captured values. Use $MyVar for variables. Use $MyVar[0], $MyVar[1], $MyVar[2], ... for variables with multiple values."/>
+              </n-scrollbar>
             </n-form-item>
           </n-grid-item>
           <n-grid-item>
-            <n-switch class="triggerSharedSwitch" v-model:value="triggerModel.shared" :disabled="triggerModel.key < 1" aria-label="Shared" @update:value="changeTriggerShared">
+            <n-button type="success" ghost @click="newTrigger">New</n-button>
+          </n-grid-item>
+
+          <n-grid-item :span="2">
+            <n-button type="warning" ghost @click="saveTrigger" style="margin-right: 8px;">Save</n-button>
+            <n-button type="error" ghost @click="deleteTrigger(triggerModel.key)">Delete</n-button>
+          </n-grid-item>
+        </n-grid>
+      </n-grid-item>
+
+      <!-- Variables section: -->
+      <n-grid-item span="3 1100:2">
+        <n-grid :cols="2" :x-gap="12">
+          <n-grid-item :span="2">
+            <h3>Variables</h3>
+            <hr style="margin-bottom: 12px"/>
+          </n-grid-item>
+          <n-grid-item>
+            <n-tree
+                block-line
+                virtual-scroll
+                :data="variableTreeData"
+                :selected-keys="selectedVariableKeys"
+                @update:selected-keys="updateSelectedVariableKeys"
+            />
+          </n-grid-item>
+
+          <n-grid-item>
+            <n-switch class="variableSharedSwitch" v-model:value="variableModel.shared"
+                      :disabled="variableModel.key < 1" aria-label="Shared" @update:value="changeVariableShared">
               <template #checked>
                 Shared across characters
               </template>
               <template #unchecked>
-                {{ state.name }}'s trigger
+                {{ state.name }}'s variable
               </template>
             </n-switch>
+            <n-form-item path="variable-name" label="Name">
+              <n-input v-model:value="variableModel.name" :disabled="variableModel.key < 1"
+                       :allow-input="onlyAlphaNumericMax50"
+                       placeholder="Variable name"/>
+            </n-form-item>
+            <n-form-item path="variable-value" label="Value">
+              <n-scrollbar>
+                <n-input v-model:value="variableModel.values" :disabled="variableModel.key < 1" type="textarea"
+                         placeholder="Value(s) on separate lines." style="height: 110px"/>
+              </n-scrollbar>
+            </n-form-item>
+          </n-grid-item>
+          <n-grid-item>
+            <n-button type="success" ghost @click="newVariable" style="float: right">New</n-button>
+          </n-grid-item>
+
+          <n-grid-item>
+            <n-button type="error" ghost @click="deleteVariable(variableModel.key)" style="float: right">Delete
+            </n-button>
+            <n-button type="warning" ghost @click="saveVariable" style="margin-right: 8px; float: right">Save
+            </n-button>
           </n-grid-item>
         </n-grid>
-        <n-form-item path="pattern" label="Pattern">
-          <n-input v-model:value="triggerModel.pattern" :disabled="triggerModel.key < 1" placeholder="RegEx pattern (JavaScript)"/>
-        </n-form-item>
-        <n-form-item path="commands" label="Commands">
-          <n-scrollbar>
-            <n-input v-model:value="triggerModel.commands" :disabled="triggerModel.key < 1" type="textarea"
-                     placeholder="Commands to send to the server. Use $1, $2, $3, ... for captured values. Use $MyVar for variables. Use $MyVar[0], $MyVar[1], $MyVar[2], ... for variables with multiple values."/>
-          </n-scrollbar>
-        </n-form-item>
-      </n-grid-item>
-
-      <n-grid-item>
-        <n-tree
-            block-line
-            virtual-scroll
-            :data="variableTreeData"
-            :selected-keys="selectedVariableKeys"
-            @update:selected-keys="updateSelectedVariableKeys"
-        />
-      </n-grid-item>
-
-      <n-grid-item>
-        <n-switch class="variableSharedSwitch" v-model:value="variableModel.shared" :disabled="variableModel.key < 1" aria-label="Shared" @update:value="changeVariableShared">
-          <template #checked>
-            Shared across characters
-          </template>
-          <template #unchecked>
-            {{ state.name }}'s variable
-          </template>
-        </n-switch>
-        <n-form-item path="variable-name" label="Name">
-          <n-input v-model:value="variableModel.name" :disabled="variableModel.key < 1" :allow-input="onlyAlphaNumericMax50"
-                   placeholder="Variable name"/>
-        </n-form-item>
-        <n-form-item path="variable-value" label="Value">
-          <n-scrollbar>
-            <n-input v-model:value="variableModel.values" :disabled="variableModel.key < 1" type="textarea"
-                     placeholder="Value(s) on separate lines." style="height: 110px"/>
-          </n-scrollbar>
-        </n-form-item>
-      </n-grid-item>
-
-      <n-grid-item>
-        <n-button type="success" ghost @click="newTrigger">New</n-button>
-      </n-grid-item>
-
-      <n-grid-item :span="2">
-        <n-button type="warning" ghost @click="saveTrigger" style="margin-right: 8px;">Save</n-button>
-        <n-button type="error" ghost @click="deleteTrigger(triggerModel.key)">Delete</n-button>
-      </n-grid-item>
-
-      <n-grid-item>
-        <n-button type="success" ghost @click="newVariable" style="float: right">New</n-button>
-      </n-grid-item>
-
-      <n-grid-item>
-        <n-button type="error" ghost @click="deleteVariable(variableModel.key)" style="float: right">Delete</n-button>
-        <n-button type="warning" ghost @click="saveVariable" style="margin-right: 8px; float: right">Save</n-button>
       </n-grid-item>
     </n-grid>
 
@@ -303,6 +318,7 @@ window.onstorage = (event) => {
   margin-top: 125px;
   max-width: calc(100vw - 290px);
   z-index: 3;
+  overflow-y: scroll
 }
 
 .n-tree {

--- a/src/components/modals/TriggersModal.vue
+++ b/src/components/modals/TriggersModal.vue
@@ -1,130 +1,135 @@
 <template>
-  <n-card :class="getSideClass()" v-if="state.modals.triggersModal">
-    <p class="close" v-on:click="state.modals.triggersModal = false ">x</p>
+  <n-card title="Automation" v-if="state.modals.triggersModal" closable @close="state.modals.triggersModal = false">
 
-    <n-grid cols="3 1100:5" :x-gap="12" :y-gap="20">
-
-      <!-- Triggers section: -->
-      <n-grid-item :span="3">
-        <n-grid :cols="3" :x-gap="12">
-          <n-grid-item :span="3">
-            <h3>Triggers</h3>
-            <hr style="margin-bottom: 12px"/>
-          </n-grid-item>
-          <n-grid-item>
-            <n-tree
-                block-line
-                checkable
-                virtual-scroll
-                :data="triggerTreeData"
-                :checked-keys="checkedTriggerKeys"
-                :selected-keys="selectedTriggerKeys"
-                @update:checked-keys="updateCheckedTriggerKeys"
-                @update:selected-keys="updateSelectedTriggerKeys"
-            />
-          </n-grid-item>
-
-          <n-grid-item :span="2">
-            <n-grid :cols="2" :x-gap="12">
-              <n-grid-item>
-                <n-form-item path="trigger-name" label="Name">
-                  <n-input v-model:value="triggerModel.name" :disabled="triggerModel.key < 1"
-                           :allow-input="onlyAlphaNumericMax50"
-                           placeholder="Trigger name"/>
-                </n-form-item>
-              </n-grid-item>
-              <n-grid-item>
-                <n-switch class="triggerSharedSwitch" v-model:value="triggerModel.shared"
-                          :disabled="triggerModel.key < 1" aria-label="Shared" @update:value="changeTriggerShared">
-                  <template #checked>
-                    Shared across characters
-                  </template>
-                  <template #unchecked>
-                    {{ state.name }}'s trigger
-                  </template>
-                </n-switch>
-              </n-grid-item>
-            </n-grid>
-            <n-form-item path="pattern" label="Pattern">
+  <n-tabs
+    type="line"
+    pane-class="automation-tab-pane"
+    >
+    <!-- Triggers section: -->
+    <n-tab-pane name="Triggers">
+      <n-grid x-gap="24" y-gap="24" :cols="3">
+        <n-grid-item>
+          <n-grid y-gap="12" :cols="1">
+            <n-grid-item>
+              <n-tree
+              block-line
+              checkable
+              virtual-scroll
+              :data="triggerTreeData"
+              :checked-keys="checkedTriggerKeys"
+              :selected-keys="selectedTriggerKeys"
+              @update:checked-keys="updateCheckedTriggerKeys"
+              @update:selected-keys="updateSelectedTriggerKeys"
+              />
+            </n-grid-item>
+            <n-grid-item>
+              <n-button block="true" type="success" ghost @click="newTrigger">New</n-button>
+            </n-grid-item>
+          </n-grid>
+        </n-grid-item>
+        <n-grid-item :span="2">
+          <n-grid x-gap="24" :cols="4">
+            <n-grid-item :span="3">
+              <n-form-item path="trigger-name" label="Name">
+                <n-input v-model:value="triggerModel.name" :disabled="triggerModel.key < 1"
+                :allow-input="onlyAlphaNumericMax50"
+                placeholder="Trigger name"/>
+              </n-form-item>
+            </n-grid-item>
+            <n-grid-item>
+              <n-form-item label="Enabled">
+                <n-switch v-model:value="triggerModel.active" :disabled="triggerModel.key < 1" aria-label="Enabled" />
+              </n-form-item>
+            </n-grid-item>
+          </n-grid>
+          <n-form-item path="pattern" label="Pattern">
+            <n-input-group>
               <n-input v-model:value="triggerModel.pattern" :disabled="triggerModel.key < 1"
-                       placeholder="RegEx pattern (JavaScript)"/>
-            </n-form-item>
-            <n-form-item path="commands" label="Commands">
-              <n-scrollbar>
-                <n-input v-model:value="triggerModel.commands" :disabled="triggerModel.key < 1" type="textarea"
-                         placeholder="Commands to send to the server. Use $1, $2, $3, ... for captured values. Use $MyVar for variables. Use $MyVar[0], $MyVar[1], $MyVar[2], ... for variables with multiple values."/>
-              </n-scrollbar>
-            </n-form-item>
-          </n-grid-item>
-          <n-grid-item>
-            <n-button type="success" ghost @click="newTrigger">New</n-button>
-          </n-grid-item>
-
-          <n-grid-item :span="2">
-            <n-button type="warning" ghost @click="saveTrigger" style="margin-right: 8px;">Save</n-button>
-            <n-button type="error" ghost @click="deleteTrigger(triggerModel.key)">Delete</n-button>
-          </n-grid-item>
-        </n-grid>
-      </n-grid-item>
-
-      <!-- Variables section: -->
-      <n-grid-item span="3 1100:2">
-        <n-grid :cols="2" :x-gap="12">
-          <n-grid-item :span="2">
-            <h3>Variables</h3>
-            <hr style="margin-bottom: 12px"/>
-          </n-grid-item>
-          <n-grid-item>
-            <n-tree
-                block-line
-                virtual-scroll
-                :data="variableTreeData"
-                :selected-keys="selectedVariableKeys"
-                @update:selected-keys="updateSelectedVariableKeys"
-            />
-          </n-grid-item>
-
-          <n-grid-item>
-            <n-switch class="variableSharedSwitch" v-model:value="variableModel.shared"
-                      :disabled="variableModel.key < 1" aria-label="Shared" @update:value="changeVariableShared">
-              <template #checked>
-                Shared across characters
-              </template>
-              <template #unchecked>
-                {{ state.name }}'s variable
-              </template>
-            </n-switch>
-            <n-form-item path="variable-name" label="Name">
-              <n-input v-model:value="variableModel.name" :disabled="variableModel.key < 1"
-                       :allow-input="onlyAlphaNumericMax50"
-                       placeholder="Variable name"/>
-            </n-form-item>
-            <n-form-item path="variable-value" label="Value">
-              <n-scrollbar>
-                <n-input v-model:value="variableModel.values" :disabled="variableModel.key < 1" type="textarea"
-                         placeholder="Value(s) on separate lines." style="height: 110px"/>
-              </n-scrollbar>
-            </n-form-item>
-          </n-grid-item>
-          <n-grid-item>
-            <n-button type="success" ghost @click="newVariable" style="float: right">New</n-button>
-          </n-grid-item>
-
-          <n-grid-item>
-            <n-button type="error" ghost @click="deleteVariable(variableModel.key)" style="float: right">Delete
+              placeholder="RegEx pattern (JavaScript)"/>
+              <!-- <n-select :style="{ width: '35%' }" :disabled="triggerModel.key < 1" default-value="RegEx" :options="[{'label': 'Exact Match', 'value': 'substring'}, {'label': 'RegEx', 'value': 'regex'}]" /> -->
+            </n-input-group>
+          </n-form-item>
+          <n-form-item path="commands" label="Commands">
+            <n-scrollbar>
+              <n-input v-model:value="triggerModel.commands" :disabled="triggerModel.key < 1" type="textarea"
+              placeholder="Commands to send to the server. Use $1, $2, $3, ... for captured values. Use $MyVar for variables. Use $MyVar[0], $MyVar[1], $MyVar[2], ... for variables with multiple values."/>
+            </n-scrollbar>
+          </n-form-item>
+          <n-checkbox v-model:checked="triggerModel.shared" :disabled="triggerModel.key < 1" aria-label="Share across characters" @update:checked="changeTriggerShared">
+            Share across characters
+          </n-checkbox>
+          <n-space justify="end" style="margin-top: 1.5em;">
+            <n-button quaternary type="error" ghost :disabled="triggerModel.key < 1" @click="deleteTrigger(triggerModel.key)">Delete</n-button>
+            <n-button type="warning" ghost :disabled="triggerModel.key < 1" @click="saveTrigger">Save</n-button>
+          </n-space>
+        </n-grid-item>
+      </n-grid>
+    </n-tab-pane>
+    <!-- Variables section: -->
+    <n-tab-pane name="Variables">
+      <n-grid x-gap="24" y-cap="24" :cols="3">
+        <n-grid-item>
+          <n-grid y-gap="12" :cols="1">
+            <n-grid-item>
+              <n-tree
+              block-line
+              virtual-scroll
+              :data="variableTreeData"
+              :selected-keys="selectedVariableKeys"
+              @update:selected-keys="updateSelectedVariableKeys"
+              />
+            </n-grid-item>
+            <n-grid-item>
+              <n-button block="true" type="success" ghost @click="newVariable">New</n-button>
+            </n-grid-item>
+          </n-grid>
+        </n-grid-item>
+        <n-grid-item :span="2">
+          <n-form-item path="variable-name" label="Name">
+            <n-input v-model:value="variableModel.name" :disabled="variableModel.key < 1"
+            :allow-input="onlyAlphaNumericMax50"
+            placeholder="Variable name"/>
+          </n-form-item>
+          <n-form-item path="variable-value" label="Value">
+            <n-scrollbar>
+              <n-input v-model:value="variableModel.values" :disabled="variableModel.key < 1" type="textarea"
+              placeholder="Value(s) on separate lines." style="height: 110px"/>
+            </n-scrollbar>
+          </n-form-item>
+          <n-checkbox v-model:checked="variableModel.shared" :disabled="variableModel.key < 1" aria-label="Share across characters" @update:checked="changeVariableShared">
+            Share across characters
+          </n-checkbox>
+          <n-space justify="end" style="margin-top: 1.5em">
+            <n-button quatenary type="error" ghost :disabled="variableModel.key < 1" @click="deleteVariable(variableModel.key)">Delete
             </n-button>
-            <n-button type="warning" ghost @click="saveVariable" style="margin-right: 8px; float: right">Save
+            <n-button type="warning" ghost :disabled="variableModel.key < 1" @click="saveVariable">Save
             </n-button>
-          </n-grid-item>
-        </n-grid>
-      </n-grid-item>
-    </n-grid>
-
-  </n-card>
+          </n-space>
+        </n-grid-item>
+      </n-grid>
+    </n-tab-pane>
+  </n-tabs>
+</n-card>
 </template>
 
 <script setup>
-import { NButton, NCard, NFormItem, NGrid, NGridItem, NInput, NScrollbar, NSwitch, NTree } from 'naive-ui'
+import { 
+  NButton, 
+  NTabs, 
+  NTabPane, 
+  NCard, 
+  NFormItem, 
+  NGrid, 
+  NGridItem, 
+  NInput, 
+  NInputGroup, 
+  // NSelect, 
+  NScrollbar, 
+  NSpace,
+  NSwitch, 
+  NCheckbox, 
+  NTree 
+} from 'naive-ui'
 import { state } from '@/composables/state'
 import { useKeyHandler } from '@/composables/key_handler'
 import { onMounted, ref } from "vue"
@@ -141,10 +146,6 @@ const variableModel = ref({ key: '-1', name: "", values: "", shared: false })
 const variableTreeData = ref([])
 const selectedVariableKeys = ref([])
 
-function getSideClass() {
-  return state.options.swapControls ? 'triggers-modal-right' : 'triggers-modal-left'
-}
-
 const updateCheckedTriggerKeys = (keys) => {
   Array.from(state.triggers.value.values()).forEach(t => t.active = false)
   keys.forEach(key => {
@@ -152,6 +153,7 @@ const updateCheckedTriggerKeys = (keys) => {
   })
   checkedTriggerKeys.value = keys
   storeSettingsOfType(state.triggers, 'triggers')
+  updateSelectedTriggerKeys([triggerModel.value.key])
 }
 
 const updateSelectedTriggerKeys = (keys) => {
@@ -164,6 +166,7 @@ const updateSelectedTriggerKeys = (keys) => {
     triggerModel.value.pattern = trigger.patterns[0]
     triggerModel.value.commands = trigger.commands
     triggerModel.value.shared = trigger.shared
+    triggerModel.value.active = trigger.active
   }
 }
 
@@ -180,7 +183,7 @@ const updateSelectedVariableKeys = (keys) => {
 }
 
 function onlyAlphaNumericMax50(value) {
-  return /^[a-zA-Z][a-zA-Z0-9]{0,50}$/.test(value) || !value
+  return /^[a-zA-Z][a-zA-Z0-9\s]{0,50}$/.test(value) || !value
 }
 
 function changeTriggerShared(shared) {
@@ -215,16 +218,16 @@ onKeydown((ev) => {
 
 function newTrigger() {
   let key = getNextKey(state.triggers.value) + ''
-  triggerModel.value = { key, name: 'NewTrigger', pattern: null, commands: null, active: false, shared: false }
-  state.triggers.value.set(key, { name: 'NewTrigger', patterns: [''], commands: null, active: false, shared: false })
+  triggerModel.value = { key, name: 'New Trigger', pattern: null, commands: null, active: false, shared: false }
+  state.triggers.value.set(key, { name: 'New Trigger', patterns: [''], commands: null, active: false, shared: false })
   updateTriggerTree()
   storeSettingsOfType(state.triggers, 'triggers')
 }
 
 function newVariable() {
   let key = getNextKey(state.variables.value) + ''
-  variableModel.value = { key, name: 'NewVariable', values: null, shared: false }
-  state.variables.value.set(key, { name: 'NewVariable', values: null, shared: false })
+  variableModel.value = { key, name: 'New Variable', values: null, shared: false }
+  state.variables.value.set(key, { name: 'New Variable', values: null, shared: false })
   updateVariableTree()
   storeSettingsOfType(state.variables, 'variables')
 }
@@ -237,6 +240,7 @@ function saveTrigger(e) {
     trigger.patterns[0] = triggerModel.value.pattern
     trigger.commands = triggerModel.value.commands
     trigger.shared = triggerModel.value.shared
+    trigger.active = triggerModel.value.active
     updateTriggerTree()
     storeSettingsOfType(state.triggers, 'triggers')
   }
@@ -315,10 +319,19 @@ window.onstorage = (event) => {
 
 .n-card {
   position: absolute;
-  margin-top: 125px;
+  margin-top: 35px;
+  width: 800px;
   max-width: calc(100vw - 290px);
   z-index: 3;
-  overflow-y: scroll
+  overflow-y: scroll;
+  left: 0; /* align center */
+  right: 0; /* align center */
+  margin-left: auto; /* align center */
+  margin-right: auto; /* align center */
+}
+
+.automation-tab-pane {
+  margin-top: 1em;
 }
 
 .n-tree {
@@ -327,30 +340,4 @@ window.onstorage = (event) => {
   background-color: #303033
 }
 
-.triggerSharedSwitch {
-  width: 100%;
-  margin-top: 32px;
-}
-
-.variableSharedSwitch {
-  width: 100%;
-  margin-top: 16px;
-  margin-bottom: 16px;
-}
-
-.triggers-modal-left {
-  left: 8px
-}
-
-.triggers-modal-right {
-  right: 8px;
-}
-
-.close {
-  position: absolute;
-  top: -10px;
-  right: 10px;
-  cursor: pointer;
-  font-size: 1.4em;
-}
 </style>

--- a/src/components/modals/TriggersModal.vue
+++ b/src/components/modals/TriggersModal.vue
@@ -93,7 +93,7 @@ const updateSelectedKeys = (keys) => {
     let trigger = state.triggers.value.get(key)
     model.value.key = key
     model.value.name = trigger.name
-    model.value.pattern = trigger.pattern
+    model.value.pattern = trigger.patterns[0]
     model.value.commands = trigger.commands
     model.value.shared = trigger.shared
   }
@@ -131,7 +131,7 @@ onKeydown((ev) => {
 function newTrigger() {
   let key = getNextKey()
   model.value = { key, name: 'NewTrigger', pattern: null, commands: null, active: false, shared: false }
-  state.triggers.value.set(key, { name: 'NewTrigger', pattern: null, commands: null, active: false, shared: false })
+  state.triggers.value.set(key, { name: 'NewTrigger', patterns: [''], commands: null, active: false, shared: false })
   updateTriggerTree()
   storeTriggers()
 }
@@ -141,7 +141,7 @@ function saveTrigger(e) {
   if (model.value.name && onlyAlphaNumericMax50(model.value.name)) {
     let trigger = state.triggers.value.get(model.value.key)
     trigger.name = model.value.name
-    trigger.pattern = model.value.pattern
+    trigger.patterns[0] = model.value.pattern
     trigger.commands = model.value.commands
     trigger.shared = model.value.shared
     updateTriggerTree()

--- a/src/components/modals/TriggersModal.vue
+++ b/src/components/modals/TriggersModal.vue
@@ -1,0 +1,192 @@
+<template>
+  <n-card title="Triggers" :class="getSideClass()" v-if="state.modals.triggersModal">
+    <p class="close" v-on:click="state.modals.triggersModal = false ">x</p>
+
+    <n-grid :cols="3" :x-gap="16">
+      <n-grid-item>
+        <n-tree
+            block-line
+            checkable
+            virtual-scroll
+            style="height: 300px"
+            :data="data"
+            :default-checked-keys="defaultCheckedKeys"
+            @update:checked-keys="updateCheckedKeys"
+            @update:selected-keys="updateSelectedKeys"
+        />
+      </n-grid-item>
+
+      <n-grid-item :span="2">
+        <n-form ref="formRef" :model="model" :rules="rules" size="large">
+          <n-form-item path="name" label="Trigger name">
+            <n-input v-model:value="model.name" placeholder="Trigger name"/>
+          </n-form-item>
+          <n-form-item path="pattern" label="Pattern">
+            <n-input v-model:value="model.pattern" placeholder="RegEx pattern"/>
+          </n-form-item>
+          <n-form-item path="commands" label="Commands">
+            <n-scrollbar>
+              <n-input v-model:value="model.commands" type="textarea" placeholder="Commands to send to the server"/>
+            </n-scrollbar>
+          </n-form-item>
+        </n-form>
+      </n-grid-item>
+
+      <n-grid-item>
+        <n-button type="info" ghost @click="newTrigger" style="margin-right: 8px;">New</n-button>
+      </n-grid-item>
+
+      <n-grid-item :span="2">
+        <n-button type="success" ghost @click="saveTrigger" style="margin-right: 8px;">Save</n-button>
+        <n-button type="error" ghost @click="deleteTrigger(model.name)">Delete</n-button>
+      </n-grid-item>
+    </n-grid>
+
+  </n-card>
+</template>
+
+<script setup>
+import {NButton, NCard, NForm, NFormItem, NGrid, NGridItem, NInput, NScrollbar, NTree} from 'naive-ui'
+import { state} from '@/composables/state'
+import { useKeyHandler} from '@/composables/key_handler'
+import { onMounted, ref} from "vue";
+
+const { onKeydown, keyState } = useKeyHandler()
+
+const formRef = ref(null)
+
+const model = ref({
+  name: null,
+  pattern: null,
+  commands: null
+})
+
+const data = ref([])
+const defaultCheckedKeys = ref([])
+
+const updateCheckedKeys = (keys) => {
+  Array.from(state.triggers.values()).forEach(t => t.active = false)
+  keys.forEach(key => state.triggers.get(key).active = true)
+}
+
+const updateSelectedKeys = (keys) => {
+
+  if (keys.length === 1) {
+    let trigger = state.triggers.get(keys[0]);
+    model.value.name = trigger.name
+    model.value.pattern = trigger.pattern
+    model.value.commands = trigger.commands
+  }
+}
+
+const rules = {
+  name: [
+    {
+      required: true,
+      trigger: ['blur'],
+      validator (rule, value) {
+        if (!value) {
+          return new Error('Name is required')
+        } else if (!/^[a-zA-Z0-9]+$/.test(value)) {
+          return new Error('Name can only contain letters and numbers')
+        }
+      }
+    }
+  ]}
+
+function getSideClass() {
+  return state.options.swapControls ? 'triggers-modal-right' : 'triggers-modal-left'
+}
+
+onKeydown((ev) => {
+  if (keyState.alt || keyState.ctrl) {
+    return false
+  }
+
+  if (state.mode === 'input') {
+    return false
+  }
+
+  if (ev.code === 'KeyT') {
+    state.modals.triggersModal = !state.modals.triggersModal
+    return true
+  }
+})
+
+function newTrigger() {
+  model.value = { name: null, pattern: null, commands: null, active: false }
+}
+
+function saveTrigger(e) {
+  e.preventDefault()
+  if (model.value.name) {
+    let trigger = {name: model.value.name, pattern: model.value.pattern, commands: model.value.commands, active: false}
+
+    state.triggers.set(trigger.name, trigger)
+    updateTriggerList()
+    storeTriggers();
+  }
+}
+
+function deleteTrigger(name) {
+  state.triggers.delete(name)
+  model.value = { name: null, pattern: null, commands: null }
+  updateTriggerList()
+  storeTriggers();
+}
+
+function updateTriggerList() {
+  let triggers = Array.from(state.triggers.values());
+  data.value = triggers.map(t => {
+    return { label: t.name, key: t.name }
+  })
+  defaultCheckedKeys.value = triggers.filter(t => t.active).map(t => t.name)
+}
+
+function storeTriggers() {
+  console.log('SAVING ' + JSON.stringify(Array.from(state.triggers.entries())))
+  localStorage.setItem('triggers', JSON.stringify(Array.from(state.triggers.entries())))
+}
+
+onMounted(() => {
+
+  try {
+    const triggers = new Map(JSON.parse(localStorage.getItem('triggers')))
+    if (triggers !== null) {
+      state.triggers = triggers
+    }
+  } catch (err) {
+    console.log(err.stack)
+    localStorage.setItem('triggers', '[]')
+  }
+
+  updateTriggerList()
+})
+
+</script>
+
+<style scoped lang="less">
+
+.n-card {
+  position: absolute;
+  margin-top: 125px;
+  max-width: calc(100vw - 710px);
+  z-index: 3;
+}
+
+.triggers-modal-left {
+  left: 45px
+}
+
+.triggers-modal-right {
+  right: 45px;
+}
+
+.close {
+  position: absolute;
+  top: -10px;
+  right: 10px;
+  cursor: pointer;
+  font-size: 1.4em;
+}
+</style>

--- a/src/components/modals/TriggersModal.vue
+++ b/src/components/modals/TriggersModal.vue
@@ -177,13 +177,13 @@ const updateSelectedVariableKeys = (keys) => {
     let variable = state.variables.value.get(key)
     variableModel.value.key = key
     variableModel.value.name = variable.name
-    variableModel.value.values = variable.values.join('\n')
+    variableModel.value.values = variable.values
     variableModel.value.shared = variable.shared
   }
 }
 
 function onlyAlphaNumericMax50(value) {
-  return /^[a-zA-Z][a-zA-Z0-9\s]{0,50}$/.test(value) || !value
+  return /^[a-zA-Z][a-zA-Z0-9]{0,50}$/.test(value) || !value
 }
 
 function changeTriggerShared(shared) {
@@ -218,16 +218,16 @@ onKeydown((ev) => {
 
 function newTrigger() {
   let key = getNextKey(state.triggers.value) + ''
-  triggerModel.value = { key, name: 'New Trigger', pattern: null, commands: null, active: false, shared: false }
-  state.triggers.value.set(key, { name: 'New Trigger', patterns: [''], commands: null, active: false, shared: false })
+  triggerModel.value = { key, name: 'NewTrigger', pattern: null, commands: null, active: false, shared: false }
+  state.triggers.value.set(key, { name: 'NewTrigger', patterns: [''], commands: null, active: false, shared: false })
   updateTriggerTree()
   storeSettingsOfType(state.triggers, 'triggers')
 }
 
 function newVariable() {
   let key = getNextKey(state.variables.value) + ''
-  variableModel.value = { key, name: 'New Variable', values: null, shared: false }
-  state.variables.value.set(key, { name: 'New Variable', values: null, shared: false })
+  variableModel.value = { key, name: 'NewVariable', values: null, shared: false }
+  state.variables.value.set(key, { name: 'NewVariable', values: null, shared: false })
   updateVariableTree()
   storeSettingsOfType(state.variables, 'variables')
 }

--- a/src/components/side-menu/MapActions.vue
+++ b/src/components/side-menu/MapActions.vue
@@ -30,6 +30,10 @@ onKeydown((ev) => {
     return false
   }
 
+  if (state.modals.triggersModal) {
+    return false
+  }
+
   if (state.gameState.battle.active) {
     return false
   }

--- a/src/components/side-menu/MoveControls.vue
+++ b/src/components/side-menu/MoveControls.vue
@@ -138,6 +138,10 @@ onKeydown((ev) => {
     return false
   }
 
+  if (state.modals.triggersModal) {
+    return false
+  }
+
   if (state.options.wasdMovement) {
     if (ev.key == 'Q' || ev.key == 'q') {
       move('northwest')

--- a/src/components/side-menu/OptionsMenu.vue
+++ b/src/components/side-menu/OptionsMenu.vue
@@ -90,6 +90,7 @@
       </template>
     </n-switch>
 
+    <n-button type="info" @click="state.modals.triggersModal = !state.modals.triggersModal" ghost>Triggers</n-button>
     <n-button type="success" @click="goFullscreen()" ghost>Full Screen</n-button>
     <n-button type="warning" @click="state.showHelp = !state.showHelp" ghost>Help</n-button>
     <n-button type="error" @click="state.showLogout = true" ghost>Logout</n-button>

--- a/src/composables/event_handler.js
+++ b/src/composables/event_handler.js
@@ -1,8 +1,8 @@
-import {processTriggers} from "@/composables/triggers";
 
 const { ansiSpan } = require('ansi-to-span')
 
-import { state, addLine } from '@/composables/state'
+import { processTriggers } from "@/composables/triggers"
+import { addLine, state } from '@/composables/state'
 import { helpers } from '@/composables/helpers'
 
 const { ansiToHtml } = helpers()

--- a/src/composables/state.js
+++ b/src/composables/state.js
@@ -42,6 +42,7 @@ export const state = reactive({
 
   animations: [],
   triggers: ref(new Map()),
+  variables: ref(new Map()),
 
   name: '',
   token: '',
@@ -70,6 +71,7 @@ export function resetState () {
   state.newbie = []
   state.animations = []
   state.triggers.value = new Map()
+  state.variables.value = new Map()
 }
 
 function resetCache () {

--- a/src/composables/state.js
+++ b/src/composables/state.js
@@ -41,7 +41,7 @@ export const state = reactive({
   newbie: [],
 
   animations: [],
-  triggers: new Map(),
+  triggers: ref(new Map()),
 
   name: '',
   token: '',
@@ -69,7 +69,7 @@ export function resetState () {
   state.trade = []
   state.newbie = []
   state.animations = []
-  state.triggers = new Map()
+  state.triggers.value = new Map()
 }
 
 function resetCache () {

--- a/src/composables/state.js
+++ b/src/composables/state.js
@@ -41,6 +41,7 @@ export const state = reactive({
   newbie: [],
 
   animations: [],
+  triggers: new Map(),
 
   name: '',
   token: '',
@@ -51,7 +52,8 @@ export const state = reactive({
       mercItemModal: ref('')
     },
     mapModal: false,
-    mercModal: false
+    mercModal: false,
+    triggersModal: false,
   }
 })
 
@@ -67,6 +69,7 @@ export function resetState () {
   state.trade = []
   state.newbie = []
   state.animations = []
+  state.triggers = new Map()
 }
 
 function resetCache () {

--- a/src/composables/triggers.js
+++ b/src/composables/triggers.js
@@ -3,6 +3,28 @@ import {useWebSocket} from '@/composables/web_socket'
 
 const { cmd } = useWebSocket()
 
+export function loadTriggers(name) {
+  let privateTriggers = loadTriggersByStorageKey('triggers-' + name.toLowerCase())
+  let sharedTriggers = loadTriggersByStorageKey('triggers')
+  state.triggers.value = new Map([...privateTriggers, ...sharedTriggers])
+}
+
+function loadTriggersByStorageKey(key) {
+  try {
+    return new Map(JSON.parse(localStorage.getItem(key)))
+  } catch (err) {
+    localStorage.setItem(key, '[]')
+  }
+}
+
+export function storeTriggers() {
+  let triggerEntries = Array.from(state.triggers.value.entries())
+  let privateTriggers = triggerEntries.filter(entry => !entry[1].shared)
+  let sharedTriggers = triggerEntries.filter(entry => entry[1].shared)
+  localStorage.setItem('triggers-' + state.name.toLowerCase(), JSON.stringify(privateTriggers))
+  localStorage.setItem('triggers', JSON.stringify(sharedTriggers))
+}
+
 export function processTriggers(line) {
   if (line) {
     state.triggers.value

--- a/src/composables/triggers.js
+++ b/src/composables/triggers.js
@@ -3,8 +3,8 @@ import { useWebSocket } from '@/composables/web_socket'
 
 const { cmd } = useWebSocket()
 
-const assignmentPattern = '^([a-zA-Z][a-zA-Z0-9]{1,50}) = (.+)$';
-const listValuePattern = '^{(.*)}$';
+const assignmentPattern = '^([a-zA-Z][a-zA-Z0-9]{1,50}) = (.+)$'
+const listValuePattern = '^{(.*)}$'
 
 export function loadSettingsByNameAndType(settings, name, settingsType) {
   let privateSettings = loadSettingsByStorageKey(settingsType + '-' + name.toLowerCase())
@@ -61,16 +61,17 @@ function processTrigger(trigger, line) {
     trigger.commands
         .split('\n')
         .filter(command => command)
-        .forEach(command => processCommand(command, matches, trigger.shared))
+        .map(command => substitutePatternMatches(matches, command))
+        .forEach(commandWithMatches => processCommand(commandWithMatches, matches, trigger.shared))
   }
 }
 
-function processCommand(command, matches, isTriggerShared) {
-  let assignmentParts = command.match(assignmentPattern)
+function processCommand(commandWithMatches, isTriggerShared) {
+  let assignmentParts = commandWithMatches.match(assignmentPattern)
   if (assignmentParts) {
     assignValueToVariable(assignmentParts, isTriggerShared)
   } else {
-    executeCommand(matches, command);
+    executeCommand(commandWithMatches)
   }
 }
 
@@ -95,8 +96,7 @@ function assignValueToVariable(assignmentParts, isTriggerShared) {
   window.onstorage({ key: 'variables' })
 }
 
-function executeCommand(matches, command) {
-  let commandWithMatches = substitutePatternMatches(matches, command)
+function executeCommand(commandWithMatches) {
   let commandWithMatchesAndVariables = substituteVariables(commandWithMatches)
   cmd(commandWithMatchesAndVariables, null, true)
 }

--- a/src/composables/triggers.js
+++ b/src/composables/triggers.js
@@ -6,7 +6,23 @@ const { cmd } = useWebSocket()
 export function loadTriggers(name) {
   let privateTriggers = loadTriggersByStorageKey('triggers-' + name.toLowerCase())
   let sharedTriggers = loadTriggersByStorageKey('triggers')
+
+  let privateKeys = [...privateTriggers.keys()]
+  let sharedKeys = [...sharedTriggers.keys()]
+  let clashingKeys = privateKeys.filter(key => sharedKeys.includes(key))
+  clashingKeys.forEach(key => {
+    let triggerToGiveNewKey = privateTriggers.get(key)
+    let newKey = Math.max(getNextId(privateTriggers), getNextId(sharedTriggers))
+    privateTriggers.set(newKey, triggerToGiveNewKey)
+  })
+
   state.triggers.value = new Map([...privateTriggers, ...sharedTriggers])
+}
+
+export function getNextId(triggers = state.triggers.value) {
+  let idsAsNumbers = [...triggers.keys()].map(k => Number(k))
+  let id = 1 + (triggers.size ? Math.max(...idsAsNumbers) : 0) + ''
+  return id
 }
 
 function loadTriggersByStorageKey(key) {
@@ -45,12 +61,12 @@ function processTrigger(trigger, line) {
 }
 
 function processCommand(matches, command) {
-  let commandWithMatches = matches.reduce((accu, match, index) => accu.replace('$' + index, match), command);
+  let commandWithMatches = matches.reduce((accu, match, index) => accu.replace('$' + index, match), command)
   cmd(commandWithMatches, null, true)
 }
 
 function stripHtml(line) {
-  let tempDivElement = document.createElement("div");
-  tempDivElement.innerHTML = line;
+  let tempDivElement = document.createElement("div")
+  tempDivElement.innerHTML = line
   return tempDivElement.textContent || tempDivElement.innerText
 }

--- a/src/composables/triggers.js
+++ b/src/composables/triggers.js
@@ -3,32 +3,27 @@ import { useWebSocket } from '@/composables/web_socket'
 
 const { cmd } = useWebSocket()
 
-export function loadTriggers(name) {
-  let privateTriggers = loadTriggersByStorageKey('triggers-' + name.toLowerCase())
-  let sharedTriggers = loadTriggersByStorageKey('triggers')
+export function loadSettingsByNameAndType(settings, name, settingsType) {
+  let privateSettings = loadSettingsByStorageKey(settingsType + '-' + name.toLowerCase())
+  let sharedSettings = loadSettingsByStorageKey(settingsType)
 
-  let privateKeys = [...privateTriggers.keys()]
-  let sharedKeys = [...sharedTriggers.keys()]
+  let privateKeys = [...privateSettings.keys()]
+  let sharedKeys = [...sharedSettings.keys()]
   let clashingKeys = privateKeys.filter(key => sharedKeys.includes(key))
   clashingKeys.forEach(key => {
-    let triggerToGiveNewKey = privateTriggers.get(key)
-    let newKey = Math.max(getNextKey(privateTriggers), getNextKey(sharedTriggers))
-    privateTriggers.set(newKey, triggerToGiveNewKey)
+    let triggerToGiveNewKey = privateSettings.get(key)
+    let newKey = Math.max(getNextKey(privateSettings), getNextKey(sharedSettings))
+    privateSettings.set(newKey, triggerToGiveNewKey)
   })
 
   if (clashingKeys.length) {
-    storeTriggers()
+    storeSettingsOfType(settings.value, settingsType)
   }
 
-  state.triggers.value = new Map([...privateTriggers, ...sharedTriggers])
+  settings.value = new Map([...privateSettings, ...sharedSettings])
 }
 
-export function getNextKey(triggers = state.triggers.value) {
-  let idsAsNumbers = [...triggers.keys()].map(k => Number(k))
-  return 1 + (triggers.size ? Math.max(...idsAsNumbers) : 0) + ''
-}
-
-function loadTriggersByStorageKey(key) {
+function loadSettingsByStorageKey(key) {
   try {
     return new Map(JSON.parse(localStorage.getItem(key)))
   } catch (err) {
@@ -36,12 +31,17 @@ function loadTriggersByStorageKey(key) {
   }
 }
 
-export function storeTriggers() {
-  let triggerEntries = Array.from(state.triggers.value.entries())
-  let privateTriggers = triggerEntries.filter(entry => !entry[1].shared)
-  let sharedTriggers = triggerEntries.filter(entry => entry[1].shared)
-  localStorage.setItem('triggers-' + state.name.toLowerCase(), JSON.stringify(privateTriggers))
-  localStorage.setItem('triggers', JSON.stringify(sharedTriggers))
+export function getNextKey(settings) {
+  let idsAsNumbers = [...settings.keys()].map(k => Number(k))
+  return 1 + (settings.size ? Math.max(...idsAsNumbers) : 0)
+}
+
+export function storeSettingsOfType(settings, settingsType) {
+  let settingsEntries = Array.from(settings.value.entries())
+  let privateSettings = settingsEntries.filter(entry => !entry[1].shared)
+  let sharedSettings = settingsEntries.filter(entry => entry[1].shared)
+  localStorage.setItem(settingsType + '-' + state.name.toLowerCase(), JSON.stringify(privateSettings))
+  localStorage.setItem(settingsType, JSON.stringify(sharedSettings))
 }
 
 export function processTriggers(line) {

--- a/src/composables/triggers.js
+++ b/src/composables/triggers.js
@@ -1,0 +1,34 @@
+import {state} from '@/composables/state'
+import {useWebSocket} from '@/composables/web_socket'
+
+const { cmd } = useWebSocket()
+
+export function processTriggers(line) {
+  if (line) {
+    state.triggers.value
+        .forEach(trigger => processTrigger(trigger, stripHtml(line)))
+  }
+}
+
+function processTrigger(trigger, line) {
+  if (trigger.active && trigger.pattern && trigger.commands) {
+    let matches = line.match(trigger.pattern)
+    if (matches) {
+      trigger.commands
+          .split('\n')
+          .filter(command => command)
+          .forEach(command => processCommand(matches, command))
+    }
+  }
+}
+
+function processCommand(matches, command) {
+  let commandWithMatches = matches.reduce((accu, match, index) => accu.replace('$' + index, match), command);
+  cmd(commandWithMatches, null, true)
+}
+
+function stripHtml(line) {
+  let tempDivElement = document.createElement("div");
+  tempDivElement.innerHTML = line;
+  return tempDivElement.textContent || tempDivElement.innerText
+}

--- a/src/composables/triggers.js
+++ b/src/composables/triggers.js
@@ -1,5 +1,5 @@
-import {state} from '@/composables/state'
-import {useWebSocket} from '@/composables/web_socket'
+import { state } from '@/composables/state'
+import { useWebSocket } from '@/composables/web_socket'
 
 const { cmd } = useWebSocket()
 
@@ -12,17 +12,20 @@ export function loadTriggers(name) {
   let clashingKeys = privateKeys.filter(key => sharedKeys.includes(key))
   clashingKeys.forEach(key => {
     let triggerToGiveNewKey = privateTriggers.get(key)
-    let newKey = Math.max(getNextId(privateTriggers), getNextId(sharedTriggers))
+    let newKey = Math.max(getNextKey(privateTriggers), getNextKey(sharedTriggers))
     privateTriggers.set(newKey, triggerToGiveNewKey)
   })
+
+  if (clashingKeys.length) {
+    storeTriggers()
+  }
 
   state.triggers.value = new Map([...privateTriggers, ...sharedTriggers])
 }
 
-export function getNextId(triggers = state.triggers.value) {
+export function getNextKey(triggers = state.triggers.value) {
   let idsAsNumbers = [...triggers.keys()].map(k => Number(k))
-  let id = 1 + (triggers.size ? Math.max(...idsAsNumbers) : 0) + ''
-  return id
+  return 1 + (triggers.size ? Math.max(...idsAsNumbers) : 0) + ''
 }
 
 function loadTriggersByStorageKey(key) {

--- a/src/composables/triggers.js
+++ b/src/composables/triggers.js
@@ -52,8 +52,8 @@ export function processTriggers(line) {
 }
 
 function processTrigger(trigger, line) {
-  if (trigger.active && trigger.pattern && trigger.commands) {
-    let matches = line.match(trigger.pattern)
+  if (trigger.active && trigger.patterns[0] && trigger.commands) {
+    let matches = line.match(trigger.patterns[0])
     if (matches) {
       trigger.commands
           .split('\n')

--- a/src/composables/web_socket.js
+++ b/src/composables/web_socket.js
@@ -1,5 +1,5 @@
 import { addLine, state } from './state'
-import { loadTriggers } from "@/composables/triggers"
+import { loadSettingsByNameAndType } from "@/composables/triggers"
 import { useCookieHandler } from "@/composables/cookie_handler"
 
 const { readTokensFromCookie } = useCookieHandler()
@@ -37,7 +37,8 @@ export function useWebSocket () {
   }
 
   function doTokenAuth (name) {
-    loadTriggers(name)
+    loadSettingsByNameAndType(state.triggers, name, 'triggers')
+    loadSettingsByNameAndType(state.variables, name, 'variables')
     let token = readTokensFromCookie()[name]
     send('token', { name, token, width: 70, height: 24, ttype: 'play.proceduralrealms.com' })
   }

--- a/src/composables/web_socket.js
+++ b/src/composables/web_socket.js
@@ -47,16 +47,20 @@ export function useWebSocket () {
     ws.send(JSON.stringify(out))
   }
 
-  function cmd (command, id) {
+  function cmd (command, id, fromTrigger) {
     if (!id) {
       // Crude filter to avoid shouting the ugly 'look iid:123456' in the output
       const lcCmd = command.toLowerCase()
       const excludeIIDCommand = (lcCmd.includes('iid:') || lcCmd.includes('eid:')) && !lcCmd.includes('chat ') && !lcCmd.includes('say ')
           && !lcCmd.includes('trade ') && !lcCmd.includes('newbie ')
       if (!excludeIIDCommand) {
-        addLine('', 'output')
-        addLine(`<span class="player-cmd-caret">></span> <span class="player-cmd">${command}</span>`, 'output')
-        addLine('', 'output')
+        if (fromTrigger) {
+          addLine(`<span class="player-cmd-caret">> ${command}</span>`, 'output')
+        } else {
+          addLine('', 'output')
+          addLine(`<span class="player-cmd-caret">></span> <span class="player-cmd">${command}</span>`, 'output')
+          addLine('', 'output')
+        }
       }
     }
     send('cmd', command, id)

--- a/src/composables/web_socket.js
+++ b/src/composables/web_socket.js
@@ -1,4 +1,5 @@
-import { state, addLine } from './state'
+import { addLine, state } from './state'
+import { loadTriggers } from "@/composables/triggers"
 
 let ws
 
@@ -33,6 +34,7 @@ export function useWebSocket () {
   }
 
   function doTokenAuth () {
+    loadTriggers(state.name)
     send('token', { name: state.name, token: state.token, width: 70, height: 24, ttype: 'play.proceduralrealms.com' })
   }
 

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -10,6 +10,7 @@
     <n-layout>
       <MapModal></MapModal>
       <MercModal></MercModal>
+      <TriggersModal></TriggersModal>
       <div class="content-area">
         <LineOutput></LineOutput>
       </div>
@@ -34,6 +35,7 @@ import MercModal from '@/components/modals/MercModal'
 import MobileMovement from '@/components/main-area/MobileMovement.vue'
 import QuickSlots from '@/components/main-area/QuickSlots.vue'
 import SideMenu from '@/components/side-menu/SideMenu'
+import TriggersModal from "@/components/modals/TriggersModal.vue";
 
 try {
   const options = JSON.parse(localStorage.getItem('options'))


### PR DESCRIPTION
### Changes
 - Used NaiveUI's built-in NCard close prop
 - More breathing room in the Form
 - Added a (commented for now) "Select" input for future Regex and Substring match options.
 - Centered Triggers modal
 - Added "Enabled" checkbox to each TriggerModel form to reduce confusion about when a Trigger is active

### Notes
 - Variables didn't load properly for me. They returned `TypeError: t.values.join is not a function` when I select a variable from the list. They do seem to save properly though. I fixed this by removing what appears to be an unnecessary join(), as the variables were saved as a string delimited by \n anyway. 

Not sure if it's possible to commit to an existing PR. I opened a PR into @sorenmarkert's fork (https://github.com/sorenmarkert/procrealms-web-client/pull/1), but this might be easier if it's ready to go.