### PR TITLE
Fix decimals in the Effects dropdown

### DIFF
--- a/src/components/side-menu/collapse-items/EffectsCollapse.vue
+++ b/src/components/side-menu/collapse-items/EffectsCollapse.vue
@@ -54,7 +54,7 @@ function getEffectBonuses (effect) {
 
   if (effect.damageOverTime) {
     let { damLow, damHigh, damageType } = effect.damageOverTime
-    bonuses.push(`Deals ${damLow.toFixed(0)} - ${damHigh.toFixed()} ${damageType} damage every ${effect.triggerTime}s`)
+    bonuses.push(`Deals ${damLow.toFixed(0)} - ${damHigh.toFixed(0)} ${damageType} damage every ${effect.triggerTime}s`)
   }
 
   bonuses = bonuses.concat(effect.bonuses.map( ({ name, value }) => {

--- a/src/components/side-menu/collapse-items/EffectsCollapse.vue
+++ b/src/components/side-menu/collapse-items/EffectsCollapse.vue
@@ -49,12 +49,12 @@ function getEffectBonuses (effect) {
 
   if (effect.healOverTime) {
     let { healLow, healHigh } = effect.healOverTime
-    bonuses.push(`Heals ${healLow}-${healHigh} every ${effect.triggerTime}s`)
+    bonuses.push(`Heals ${healLow.toFixed(0)} - ${healHigh.toFixed(0)} every ${effect.triggerTime}s`)
   }
 
   if (effect.damageOverTime) {
     let { damLow, damHigh, damageType } = effect.damageOverTime
-    bonuses.push(`Deals ${damLow}-${damHigh} ${damageType} damage every ${effect.triggerTime}s`)
+    bonuses.push(`Deals ${damLow.toFixed(0)} - ${damHigh.toFixed()} ${damageType} damage every ${effect.triggerTime}s`)
   }
 
   bonuses = bonuses.concat(effect.bonuses.map( ({ name, value }) => {
@@ -64,10 +64,7 @@ function getEffectBonuses (effect) {
 }
 
 function isHiredEffect(effect) {
-  if (effect.longFlag && effect.longFlag.includes("Hired")) {
-    return true;
-  }
-  return false;
+  return effect.longFlag && effect.longFlag.includes("Hired")
 }
 
 </script>


### PR DESCRIPTION
Smallest of fixes :smile: 

Looks like some effects have wayyyyy too many decimals coming back from the API side. Adding `toFixed(0)` to them to keep them clean and short. 

**Before**
![image](https://github.com/dinchak/procrealms-web-client/assets/11844042/b9320d0e-07c5-4b49-8916-e851e9f9c91e)

**After**

![image](https://github.com/dinchak/procrealms-web-client/assets/11844042/f63a0c6b-1889-4748-be90-da5a70fe8b54)
