### PR TITLE
Font sizes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -78,16 +78,17 @@ function clearCache(object) {
 <style lang="less">
 @import url('https://fonts.googleapis.com/css2?family=Inconsolata&family=Open+Sans&display=swap');
 
-// @font-face {
-//   font-family: 'DOS';
-//   src: url('@/assets/WebPlus_IBM_VGA_8x16.woff') format('woff');
-// }
+@font-face {
+  font-family: 'DOS';
+  src: url('@/assets/WebPlus_IBM_VGA_8x16.woff') format('woff');
+}
 
 body, html {
   background-color: #181818;
   margin: 0;
   padding: 0;
   font-family: 'Open Sans', sans-serif;
+  font-size: 16px;
   color: #fff;
   overflow-x: hidden;
   color-scheme: dark;

--- a/src/components/SplashScreen.vue
+++ b/src/components/SplashScreen.vue
@@ -48,7 +48,7 @@ watch(() => state.connected, () => {
   user-select: none;
   min-height: 300px;
   font-size: 1rem;
-  line-height: 16px;
+  line-height: 1rem;
   white-space: pre;
   text-align: center;
 }

--- a/src/components/SplashScreen.vue
+++ b/src/components/SplashScreen.vue
@@ -47,11 +47,10 @@ watch(() => state.connected, () => {
 .picture {
   user-select: none;
   min-height: 300px;
-  font-size: 16px;
+  font-size: 1rem;
   line-height: 16px;
   white-space: pre;
   text-align: center;
-  font-family: 'Inconsolata', monospace;
 }
 
 .login-controls {
@@ -62,7 +61,7 @@ watch(() => state.connected, () => {
   display: flex;
   flex-direction: row;
   justify-content: center;
-  font-size: 22px;
+  font-size: 1.3rem;
   color: #ff9752;
   text-shadow: 0px 0px 6px #ff0000;
   button {
@@ -72,8 +71,8 @@ watch(() => state.connected, () => {
 
 @media screen and (max-width: 800px) {
   .picture {
-    font-size: 14px;
-    line-height: 14px;
+    font-size: 0.9rem;
+    line-height: 0.9rem;
   }
 }
 

--- a/src/components/main-area/BattleStatus.vue
+++ b/src/components/main-area/BattleStatus.vue
@@ -150,7 +150,7 @@ watch(state.gameState.battle.participants, function () {
         font-size: 1.4rem;
         color: #ff3333;
         &.crit {
-          line-height: 20px;
+          line-height: 1.2rem;
           font-size: 1.9rem;
           color: #ffcc33;
         }

--- a/src/components/main-area/BattleStatus.vue
+++ b/src/components/main-area/BattleStatus.vue
@@ -116,7 +116,7 @@ watch(state.gameState.battle.participants, function () {
 
   .vs {
     flex-basis: 4%;
-    font-size: 18px;
+    font-size: 1.1rem;
     color: #c50f1f;
     text-align: center;
   }
@@ -147,11 +147,11 @@ watch(state.gameState.battle.participants, function () {
         opacity: 0;
         top: 40px;
         left: 10px;
-        font-size: 20px;
+        font-size: 1.4rem;
         color: #ff3333;
         &.crit {
           line-height: 20px;
-          font-size: 30px;
+          font-size: 1.9rem;
           color: #ffcc33;
         }
       }
@@ -161,7 +161,7 @@ watch(state.gameState.battle.participants, function () {
         opacity: 0;
         top: -22px;
         left: 20px;
-        font-size: 20px;
+        font-size: 1.4rem;
         color: #33ff33;
       }
 
@@ -215,7 +215,7 @@ watch(state.gameState.battle.participants, function () {
 @media screen and (max-width: 1000px) {
   .battle-status {
     .vs {
-      font-size: 14px;
+      font-size: 0.9rem;
     }
   }
 }
@@ -223,7 +223,7 @@ watch(state.gameState.battle.participants, function () {
 @media screen and (max-width: 800px) {
   .battle-status {
     .vs {
-      font-size: 12px;
+      font-size: 0.8rem;
     }
     .side {
       .entity {

--- a/src/components/main-area/KeyboardInput.vue
+++ b/src/components/main-area/KeyboardInput.vue
@@ -221,7 +221,7 @@ onKeydown((ev) => {
 .input-wrapper {
   display: flex;
   flex-direction: row;
-  font-size: 14px;
+  font-size: 0.9rem;
   margin-top: 7px;
   // height: 40px;
   align-items: center;

--- a/src/components/main-area/LineOutput.vue
+++ b/src/components/main-area/LineOutput.vue
@@ -307,7 +307,7 @@ onMounted(() => {
     line-height: 40px;
     width: 100%;
     background-color: rgba(20, 80, 20, 0.4);
-    font-size: 24px;
+    font-size: 1.5rem;
     text-align: center;
     cursor: pointer;
     user-select: none;
@@ -357,7 +357,6 @@ onMounted(() => {
     position: relative;
     overflow-y: scroll;
     overflow-x: hidden;
-    font-family: 'Inconsolata', monospace;
 
     height: ~"calc(100vh - 85px)";
 
@@ -373,7 +372,7 @@ onMounted(() => {
     }
 
     .line {
-      font-size: 16px;
+      font-size: 1rem;
       line-height: 20px;
       display: block;
       white-space: pre-wrap;
@@ -400,20 +399,20 @@ onMounted(() => {
       }
       .from {
         .name {
-          font-size: 14px;
+          font-size: 0.9rem;
           line-height: 12px;
           text-align: right;
           word-break: break-all;
         }
         .timestamp {
-          font-size: 10px;
+          font-size: 0.6rem;
           line-height: 8px;
           text-align: right;
         }
       }
       .body {
         display: flex;
-        font-size: 20px;
+        font-size: 1.2rem;
         line-height: 20px;
         margin-left: 10px;
       }
@@ -426,14 +425,14 @@ onMounted(() => {
   .tabs {
     .output {
       .line {
-        font-size: 16px;
-        line-height: 16px;
+        font-size: 1rem;
+        line-height: 1rem;
       }
       .message {
         grid-template-columns: 90px calc(100% - 90px);
         .body {
-          font-size: 16px;
-          line-height: 16px;
+          font-size: 1rem;
+          line-height: 1rem;
         }
       }
     }

--- a/src/components/main-area/LineOutput.vue
+++ b/src/components/main-area/LineOutput.vue
@@ -373,7 +373,7 @@ onMounted(() => {
 
     .line {
       font-size: 1rem;
-      line-height: 20px;
+      line-height: 1.2rem;
       display: block;
       white-space: pre-wrap;
       font-weight: normal !important;
@@ -400,20 +400,20 @@ onMounted(() => {
       .from {
         .name {
           font-size: 0.9rem;
-          line-height: 12px;
+          line-height: 0.8rem;
           text-align: right;
           word-break: break-all;
         }
         .timestamp {
           font-size: 0.6rem;
-          line-height: 8px;
+          line-height: 0.6rem;
           text-align: right;
         }
       }
       .body {
         display: flex;
         font-size: 1.2rem;
-        line-height: 20px;
+        line-height: 1.2rem;
         margin-left: 10px;
       }
     }

--- a/src/components/main-area/MobileMovement.vue
+++ b/src/components/main-area/MobileMovement.vue
@@ -111,7 +111,7 @@ function getEnterClass () {
     flex-direction: row;
     .direction {
       opacity: 0;
-      font-size: 24px;
+      font-size: 1.5rem;
       display: flex;
       justify-content: center;
       align-items: center;

--- a/src/components/main-area/QuickSlots.vue
+++ b/src/components/main-area/QuickSlots.vue
@@ -163,13 +163,13 @@ function getSlotClass (slot) {
 
       .slot-number {
         height: 12px;
-        font-size: 14px;
+        font-size: 0.9rem;
         line-height: 12px;
       }
 
       .slot-label {
-        font-size: 10px;
-        width: 50px;
+        font-size: 0.7rem;
+        width: 3.5rem;
         max-height: 16px;
         word-wrap: break-word;
         line-height: 8px;

--- a/src/components/main-area/QuickSlots.vue
+++ b/src/components/main-area/QuickSlots.vue
@@ -112,8 +112,8 @@ function getSlotClass (slot) {
     user-select: none;
     display: flex;
     flex-direction: row;
-    // justify-content: space-between;
-    height: 40px;
+    justify-content: space-between;
+    height: 45px;
     &.show-mobile {
       margin: 0 5px;
     }
@@ -164,7 +164,7 @@ function getSlotClass (slot) {
       .slot-number {
         height: 12px;
         font-size: 0.9rem;
-        line-height: 12px;
+        line-height: 0.8rem;
       }
 
       .slot-label {
@@ -172,7 +172,7 @@ function getSlotClass (slot) {
         width: 3.5rem;
         max-height: 16px;
         word-wrap: break-word;
-        line-height: 8px;
+        line-height: 0.6rem;
         text-align: center;
       }
 

--- a/src/components/main-area/battle-items/BattleEntity.vue
+++ b/src/components/main-area/battle-items/BattleEntity.vue
@@ -116,10 +116,10 @@ function getAffects (entity) {
     flex-direction: column;
     min-height: 30px;
     .name {
-      font-size: 16px;
+      font-size: 1rem;
     }
     .affects {
-      font-size: 14px;
+      font-size: 0.9rem;
     }
     .sten {
       display: flex;
@@ -158,7 +158,7 @@ function getAffects (entity) {
   }
 
   .n-progress {
-    font-size: 14px;
+    font-size: 0.9rem;
     line-height: 14px;
     .n-progress-custom-content {
       width: 60px;
@@ -184,17 +184,17 @@ function getAffects (entity) {
     width: 150px;
     .status {
       .name {
-        font-size: 14px;
+        font-size: 0.9rem;
       }
       .affects {
-        font-size: 12px;
+        font-size: 0.8rem;
       }
     }
     .targeting {
-      font-size: 12px;
+      font-size: 0.8rem;
     }
     .n-progress {
-      font-size: 12px;
+      font-size: 0.8rem;
       line-height: 12px;
       .n-progress-custom-content {
         width: 50px;
@@ -222,18 +222,18 @@ function getAffects (entity) {
     width: 125px;
     .status {
       .name {
-        font-size: 12px;
+        font-size: 0.8rem;
       }
       .affects {
-        font-size: 10px;
+        font-size: 0.7rem;
       }
     }
     .targeting {
-      font-size: 10px;
+      font-size: 0.7rem;
     }
 
     .n-progress {
-      font-size: 10px;
+      font-size: 0.7rem;
       line-height: 10px;
       .n-progress-custom-content {
         width: 40px;

--- a/src/components/main-area/battle-items/BattleEntity.vue
+++ b/src/components/main-area/battle-items/BattleEntity.vue
@@ -159,7 +159,7 @@ function getAffects (entity) {
 
   .n-progress {
     font-size: 0.9rem;
-    line-height: 14px;
+    line-height: 0.9rem;
     .n-progress-custom-content {
       width: 60px;
       text-align: right;
@@ -195,7 +195,7 @@ function getAffects (entity) {
     }
     .n-progress {
       font-size: 0.8rem;
-      line-height: 12px;
+      line-height: 0.8rem;
       .n-progress-custom-content {
         width: 50px;
         text-align: right;
@@ -234,7 +234,7 @@ function getAffects (entity) {
 
     .n-progress {
       font-size: 0.7rem;
-      line-height: 10px;
+      line-height: 0.7rem;
       .n-progress-custom-content {
         width: 40px;
         text-align: right;

--- a/src/components/modals/ItemModal.vue
+++ b/src/components/modals/ItemModal.vue
@@ -334,7 +334,6 @@ h3 {
   font-size: 1.2em;
   overflow: scroll;
   height: calc(100vh - 95px);
-  font-family: 'Inconsolata', monospace;
 }
 
 .stats {

--- a/src/components/modals/MapModal.vue
+++ b/src/components/modals/MapModal.vue
@@ -98,7 +98,7 @@ onMounted(() => {
 .ansi {
   white-space: pre;
   font-size: 1rem;
-  line-height: 13px;
+  line-height: 0.9rem;
 }
 
 .right {

--- a/src/components/modals/MapModal.vue
+++ b/src/components/modals/MapModal.vue
@@ -96,9 +96,8 @@ onMounted(() => {
 
 <style scoped lang="less">
 .ansi {
-  font-family: 'Inconsolata', monospace;
   white-space: pre;
-  font-size: 16px;
+  font-size: 1rem;
   line-height: 13px;
 }
 

--- a/src/components/modals/MercModal.vue
+++ b/src/components/modals/MercModal.vue
@@ -133,7 +133,7 @@ function setAffects(affectList) {
 
 .n-card {
   position: absolute;
-  width: 25rem;
+  width: 400px;
   margin-top: 35px;
   z-index: 2;
   max-height: 80vh;

--- a/src/components/side-menu/MiniMap.vue
+++ b/src/components/side-menu/MiniMap.vue
@@ -26,6 +26,6 @@ function renderMap () {
   user-select: none;
   white-space: pre;
   font-size: 1.2rem;
-  line-height: 20px;
+  line-height: 1.2rem;
 }
 </style>

--- a/src/components/side-menu/MiniMap.vue
+++ b/src/components/side-menu/MiniMap.vue
@@ -25,8 +25,7 @@ function renderMap () {
 .minimap {
   user-select: none;
   white-space: pre;
-  font-size: 20px;
+  font-size: 1.2rem;
   line-height: 20px;
-  font-family: 'Inconsolata', monospace;
 }
 </style>

--- a/src/components/side-menu/MoveControls.vue
+++ b/src/components/side-menu/MoveControls.vue
@@ -183,7 +183,7 @@ onKeydown((ev) => {
     display: flex;
     flex-direction: row;
     .direction {
-      font-size: 24px;
+      font-size: 1.5rem;
       display: flex;
       justify-content: center;
       align-items: center;

--- a/src/components/side-menu/OptionsMenu.vue
+++ b/src/components/side-menu/OptionsMenu.vue
@@ -99,6 +99,26 @@
       </template>
     </n-switch>
 
+    <p>Fonts</p>
+    <n-switch v-model:value="state.options.fontFamily" aria-label="Font Family" @update:value="setFont">
+      <template #checked>
+          Inconsolata
+      </template>
+      <template #unchecked>
+          DOS
+      </template>
+    </n-switch>
+
+    <n-radio-group v-model:value="selectedFontSize" name="radiobuttongroup1" class="font-size-selector">
+      <n-radio-button
+              v-for="fontSize in fontSizes"
+              :key="fontSize.value"
+              :value="fontSize.value"
+              :label="fontSize.label"
+              @change="changeFontSize"
+      />
+    </n-radio-group>
+
     <n-button type="success" @click="goFullscreen()" ghost>Full Screen</n-button>
     <n-button type="warning" @click="state.showHelp = !state.showHelp" ghost>Help</n-button>
     <n-button type="error" @click="state.showLogout = true" ghost>Logout</n-button>
@@ -106,16 +126,44 @@
 </template>
 
 <script setup>
-import { NSwitch, NButton } from 'naive-ui'
+import { NSwitch, NButton, NRadioGroup, NRadioButton } from 'naive-ui'
 
 import { state } from '@/composables/state'
-import { watch } from 'vue';
+import { watch, ref} from 'vue';
+
+const fontSizes = [
+    {
+        value: '14px',
+        label: 'Small'
+    },
+    {
+        value: '16px',
+        label: 'Medium'
+    },
+    {
+        value: '18px',
+        label: 'Large'
+    }
+]
+
+const selectedFontSize = ref(state.options.fontSize)
 
 watch(state.options, () => localStorage.setItem('options', JSON.stringify(state.options)))
 
 function goFullscreen () {
   let app = document.getElementById('app')
   app.requestFullscreen()
+}
+
+function setFont(value) {
+    if (value) {
+        document.getElementsByTagName('body')[0].style.fontFamily = 'Inconsolata, monospace'
+    } else document.getElementsByTagName('body')[0].style.fontFamily = 'DOS, monospace'
+}
+
+function changeFontSize() {
+    state.options.fontSize = selectedFontSize.value;
+    document.getElementsByTagName('html')[0].style.fontSize = selectedFontSize.value;
 }
 
 </script>
@@ -130,6 +178,12 @@ function goFullscreen () {
     .n-switch__rail {
       width: 100%;
     }
+  }
+
+  .font-size-selector {
+    align-self: center;
+    margin-top: 5px;
+    margin-bottom: 20px;
   }
 }
 

--- a/src/components/side-menu/QuickStats.vue
+++ b/src/components/side-menu/QuickStats.vue
@@ -99,11 +99,11 @@ function entity () {
         margin-right: 0px;
       }
       .value {
-        font-size: 14px;
+        font-size: 0.9rem;
         font-weight: bold;
       }
       .label {
-        font-size: 10px;
+        font-size: 0.7rem;
       }
     }
   }
@@ -112,10 +112,9 @@ function entity () {
     display: flex;
     flex-direction: row;
     .circle-stat {
-      font-family: 'Inconsolata', monospace;
       width: 35px;
       height: 35px;
-      font-size: 10px;
+      font-size: 0.7rem;
     }
   }
    .quick-stats {

--- a/src/components/side-menu/collapse-items/CharacterCollapse.vue
+++ b/src/components/side-menu/collapse-items/CharacterCollapse.vue
@@ -241,12 +241,12 @@ function addStatPoint (stat) {
 }
 
 .add-point {
-  font-size: 16px;
+  font-size: 1rem;
   cursor: pointer;
 }
 
 .inline {
-  font-size: 16px;
+  font-size: 1rem;
   display: inline-flex;
   vertical-align: middle;
 }

--- a/src/components/side-menu/collapse-items/EquipmentRow.vue
+++ b/src/components/side-menu/collapse-items/EquipmentRow.vue
@@ -28,7 +28,7 @@ const isHead = props.slot !== 'head'
 
   .slot {
     color: #aaa;
-    font-size: 12px;
+    font-size: 0.8rem;
     text-transform: capitalize;
     display: flex;
     align-items: center;

--- a/src/composables/event_handler.js
+++ b/src/composables/event_handler.js
@@ -197,6 +197,15 @@ function loadOptions() {
     if (options !== null) {
       state.options = Object.assign(state.options, options)
     }
+
+    // Set font options
+    if (state.options.fontFamily) {
+      document.getElementsByTagName('body')[0].style.fontFamily = 'Inconsolata, monospace'
+    }  else {
+      document.getElementsByTagName('body')[0].style.fontFamily = 'DOS, monospace'
+    }
+
+    document.getElementsByTagName('html')[0].style.fontSize = state.options.fontSize;
   } catch (err) {
     console.log(err.stack)
     localStorage.setItem('options', '')

--- a/src/composables/state.js
+++ b/src/composables/state.js
@@ -123,7 +123,7 @@ function resetOptions () {
     wasdMovement: true,
     keepSentCommands: false,
     fontFamily: true,
-    fontSize: 'medium'
+    fontSize: '16px'
   }
 }
 

--- a/src/composables/state.js
+++ b/src/composables/state.js
@@ -121,7 +121,9 @@ function resetOptions () {
     showMobileMovement: false,
     numPadMovement: true,
     wasdMovement: true,
-    keepSentCommands: false
+    keepSentCommands: false,
+    fontFamily: true,
+    fontSize: 'medium'
   }
 }
 

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -57,7 +57,7 @@ import SideMenu from '@/components/side-menu/SideMenu'
       width: 100%;
 
       .map-icon {
-        font-size: 30px;
+        font-size: 1.9rem;
         text-align: left;
         cursor: pointer;
       }


### PR DESCRIPTION
Adding Font family and font size options. These are added to the options panel. The options are between the currently used `Inconsolata` font and the previously used `DOS` font. Sizes are small, medium and large. Options are stored in `localStorage`, so they will be saved and restored for the player on the browser.

**Note:** The font sizes for the item modals is not changing. This is due to the `Teleport` tag we are using there. I'll handle the item modal in a different PR, since I want to fix the styling with it anyways. 

![image](https://github.com/dinchak/procrealms-web-client/assets/11844042/6f9df174-02ba-4e53-88d7-ccbb04b710da)
