### PR TITLE
Map size set in localStorage, map position adapts in consideration wi…

### DIFF
--- a/src/components/modals/ItemModal.vue
+++ b/src/components/modals/ItemModal.vue
@@ -6,6 +6,7 @@
               style="max-height: 600px">
         <n-tab-pane name="actions" tab="Actions" class="actions-pane" style="max-height: 600px">
           <h3 v-html-safe="props.item.amount + 'x ' + ansiToHtml(props.item.colorName)"></h3>
+            <div class="item-desc" v-html-safe="ansiToHtml(getLook())"></div>
 
           <div class="actions">
             <n-button v-for="action in actions"
@@ -22,34 +23,26 @@
               {{action.split(" ").length > 1 ? action.split(" ")[1] : action}}
             </n-button>
           </div>
-
-          <n-collapse v-if="props.menu === 'inventory'" class="additional-collapse">
-            <n-collapse-item title="Additional actions">
-              <div class="additional-actions">
-                <n-button ghost type="warning" @click="giveAll()" v-if="state.gameState.mercEid !== -1">
-                  Give all
-                </n-button>
-                <div class="input-button" v-if="state.gameState.mercEid !== -1">
-                  <n-button ghost type="warning" @click="giveItems()">
-                    Give
-                  </n-button>
-                  <n-input-number class="input-field" button-placement="both" v-model:value="giveValue" min=1 :max="item.amount" />
-                </div>
-                <n-button ghost type="error" @click="dropAll()">
-                  Drop all
-                </n-button>
-                <div class="input-button">
-                  <n-button ghost type="error" @click="dropItems()">
-                    Drop
-                  </n-button>
-                  <n-input-number class="input-field" button-placement="both" v-model:value="dropValue" min=1 :max="item.amount" />
-                </div>
-              </div>
-            </n-collapse-item>
-          </n-collapse>
-        </n-tab-pane>
-        <n-tab-pane name="look" tab="Look" style="max-height: 600px">
-          <div class="item-desc" v-html-safe="ansiToHtml(getLook())"></div>
+          <div class="additional-actions">
+            <n-button ghost type="warning" @click="giveAll()" v-if="state.gameState.mercEid !== -1">
+              Give all
+            </n-button>
+            <div class="input-button" v-if="state.gameState.mercEid !== -1">
+              <n-button ghost type="warning" @click="giveItems()">
+                Give
+              </n-button>
+              <n-input-number class="input-field" button-placement="both" v-model:value="giveValue" min=1 :max="item.amount" />
+            </div>
+            <n-button ghost type="error" @click="dropAll()">
+              Drop all
+            </n-button>
+            <div class="input-button">
+              <n-button ghost type="error" @click="dropItems()">
+                Drop
+              </n-button>
+              <n-input-number class="input-field" button-placement="both" v-model:value="dropValue" min=1 :max="item.amount" />
+            </div>
+          </div>
         </n-tab-pane>
         <n-tab-pane name="examine" tab="Examine" style="max-height: 600px">
           <div class="examine" v-html-safe="ansiToHtml(rawExamine())"></div>
@@ -65,7 +58,7 @@
 </template>
 
 <script setup>
-import { NCard, NTabs, NTabPane, NButton, NCollapse, NCollapseItem, NInputNumber } from 'naive-ui'
+import { NCard, NTabs, NTabPane, NButton, NInputNumber } from 'naive-ui'
 import { defineProps, ref, watch} from 'vue'
 import { helpers } from '@/composables/helpers'
 import { useWebSocket } from '@/composables/web_socket'
@@ -269,14 +262,12 @@ function clickedAction(action) {
 
 .n-card {
   position: fixed;
-  margin-top: 3px;
-  width: calc(100vw - 280px);
-  min-width: 300px;
-  max-width: 700px;
+  margin-top: 200px;
+  width: 400px;
   z-index: 3;
   top: 0;
-  height: calc(100vh - 6px);
-  max-height: 600px;
+  min-height: 300px;
+  overflow-y: scroll;
 }
 
 .player-inventory-modal-left {
@@ -306,8 +297,6 @@ function clickedAction(action) {
 .item-desc {
   white-space: pre-wrap;
   font-size: 1.2em;
-  overflow: scroll;
-  height: calc(100vh - 95px);
 }
 
 h3 {
@@ -324,16 +313,14 @@ h3 {
 }
 
 .actions-pane {
-  overflow: scroll;
-  height: calc(100vh - 95px);
+  overflow-y: scroll;
   margin-bottom: 20px;
 }
 
 .examine {
   white-space: pre-wrap;
   font-size: 1.2em;
-  overflow: scroll;
-  height: calc(100vh - 95px);
+  overflow-y: scroll;
 }
 
 .stats {
@@ -355,6 +342,7 @@ h3 {
   display: grid;
   gap: 1em;
   grid-template-columns: 1fr 1fr 1fr;
+  overflow-y: scroll;
 
 .action {
   text-transform: capitalize;
@@ -374,11 +362,28 @@ h3 {
   display: grid;
   grid-template-columns: 1fr 2fr;
   gap: 15px;
+  margin-top: 20px;
 }
 
 .input-field {
   margin-left: 5px;
   width: 100px;
+}
+
+@media screen and (max-width: 800px) {
+  .n-card {
+    margin-top: 3px;
+    width: calc(100vw - 280px);
+    min-width: 300px;
+    max-width: 700px;
+    z-index: 3;
+    top: 0;
+    height: calc(100vh - 6px);
+  }
+
+    .merc-inventory-modal-left, .merc-inventory-modal-right {
+      left: 5px;
+    }
 }
 
 </style>

--- a/src/components/modals/MapModal.vue
+++ b/src/components/modals/MapModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <n-card title="Map" size="small" :class="['right', geMapModalSizeClass()]" v-if="state.modals.mapModal" content-style="display: flex; flex-wrap: wrap; justify-content: center; align-content:center; overflow:hidden;" closable @close="closeModal()">
+  <n-card title="Map" size="small" :class="[rightClass, geMapModalSizeClass()]" v-if="state.modals.mapModal" content-style="display: flex; flex-wrap: wrap; justify-content: center; align-content:center; overflow:hidden;" closable @close="closeModal()">
     <template #header-extra>
       <n-button text @click="toggleMapModalSize()">
         <n-icon size="15"><WindowOutlined></WindowOutlined></n-icon>
@@ -25,6 +25,7 @@ const { ansiToHtml } = helpers()
 
 const MAP_ID = command_ids.MAP
 const largeMap = ref([])
+const rightClass = ref('right')
 
 watch(() => state.cache.commandCache[MAP_ID], () => {
   if (state.modals.mapModal) {
@@ -48,6 +49,14 @@ watch(() => state.gameState.map, () => {
   }
 })
 
+watch(() => [state.modals.mercModal, state.options.swapControls, state.modals.mapModalSize], () => {
+	if (state.modals.mercModal && !state.options.swapControls && state.modals.mapModalSize !== 'large') {
+      rightClass.value = 'right-offset'
+    } else {
+		rightClass.value = 'right'
+    }
+})
+
 function toggleMapModalSize() {
   if (state.modals.mapModalSize == "small") {
     state.modals.mapModalSize = "medium"
@@ -58,6 +67,9 @@ function toggleMapModalSize() {
   else {
     state.modals.mapModalSize = "small"
   }
+
+  state.options.mapModalSize = state.modals.mapModalSize
+  localStorage.setItem('options', JSON.stringify(state.options))
 }
 
 function geMapModalSizeClass() {
@@ -107,6 +119,10 @@ onMounted(() => {
 
 .right {
   right: 10px;
+}
+
+.right-offset {
+  right: 410px;
 }
 
 .n-card {

--- a/src/components/side-menu/collapse-items/InventoryRow.vue
+++ b/src/components/side-menu/collapse-items/InventoryRow.vue
@@ -1,16 +1,22 @@
 <template>
   <div class="inventory-item">
-    <div v-html-safe="`L${props.level} ${props.amount}x ${ansiToHtml(props.colorName)}`" class="item-name"></div>
+      <n-popover trigger="hover" placement="top-start" :keep-alive-on-hover="false">
+          <template #trigger >
+              <div v-html-safe="`L${props.level} ${props.amount}x ${ansiToHtml(props.colorName)}`" class="item-name"></div>
+          </template>
+          <div v-html-safe="`${ansiToHtml(props.description)}`" class="tooltip"></div>
+      </n-popover>
   </div>
 </template>
 
 <script setup>
 import { defineProps } from 'vue'
 import { helpers } from '@/composables/helpers'
+import { NPopover } from 'naive-ui'
 
 const { ansiToHtml } = helpers()
 
-const props = defineProps(['colorName', 'amount', 'level'])
+const props = defineProps(['colorName', 'amount', 'level', 'description'])
 </script>
 
 <style scoped lang="less">
@@ -30,6 +36,10 @@ const props = defineProps(['colorName', 'amount', 'level'])
       margin: 2px 2px;
       text-transform: capitalize;
     }
+  }
+
+  .tooltip {
+    width: 200px;
   }
 
 </style>

--- a/src/composables/constants/action_mapper.js
+++ b/src/composables/constants/action_mapper.js
@@ -85,11 +85,12 @@ export const action_mapper = [
         condition: (it) => it.subtype === 'hook',
         crafting: true
     },
-    {
+    // Drop action is removed right now because it's a default action in ItemModal
+    /*{
         action: 'drop',
         condition: () => true,
         crafting: false
-    },
+    },*/
     {
         action: 'salvage',
         condition: (it) => ['armor', 'tool', 'weapon'].includes(it.type) && !it.name.includes('artifact'),

--- a/src/composables/event_handler.js
+++ b/src/composables/event_handler.js
@@ -208,7 +208,8 @@ function loadOptions() {
       document.getElementsByTagName('body')[0].style.fontFamily = 'DOS, monospace'
     }
 
-    document.getElementsByTagName('html')[0].style.fontSize = state.options.fontSize;
+    document.getElementsByTagName('html')[0].style.fontSize = state.options.fontSize
+    state.modals.mapModalSize = state.options.mapModalSize
   } catch (err) {
     console.log(err.stack)
     localStorage.setItem('options', '')

--- a/src/composables/state.js
+++ b/src/composables/state.js
@@ -128,7 +128,8 @@ function resetOptions () {
     wasdMovement: true,
     keepSentCommands: false,
     fontFamily: true,
-    fontSize: '16px'
+    fontSize: '16px',
+    mapModalSize: 'medium'
   }
 }
 


### PR DESCRIPTION
Map size is now set in settings, just like the other options, so it will be remembered on the same browser.
When map is not set to large (the full screen option) it will move to the left of the merc modal if the merc modal happens to be open. See below:

![image](https://github.com/dinchak/procrealms-web-client/assets/11844042/3396dd75-d932-458d-a643-a51121efee53)

Also included with this:

Removed the `Look` tab from `ItemModal`. `Look` information is now included with the default view of `ItemModal`, and in a on-hover popup for each item.

Also adjusted the modal CSS to look nicer on the desktop, but will keep the same for mobile.

![Screenshot_20230902_130753](https://github.com/dinchak/procrealms-web-client/assets/11844042/dd2a3d87-cc88-43ef-9c09-ee717854a92f)



