### PR TITLE
WASD movement fix for keyboard layouts

### DIFF
--- a/src/components/side-menu/BattleControls.vue
+++ b/src/components/side-menu/BattleControls.vue
@@ -44,13 +44,14 @@ onKeydown((ev) => {
   //   return true
   // }
 
-  if (ev.code == 'KeyA') {
+
+  if (ev.key === 'A' || ev.key === 'a') {
     cmd('attack')
     return true
-  } else if (ev.code == 'KeyD') {
+  } else if (ev.key === 'D' || ev.key === 'd') {
     cmd('defend')
     return true
-  } else if (ev.code == 'KeyF') {
+  } else if (ev.key === 'F' || ev.key === 'f') {
     cmd('flee')
     return true
   }

--- a/src/components/side-menu/MoveControls.vue
+++ b/src/components/side-menu/MoveControls.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="movement">
+  <div class="movement" v-if="state.options.showMapArea">
     <div class="row">
       <n-icon :class="getMovementClass('northwest')" @click="move('northwest')"><NorthWestOutlined></NorthWestOutlined></n-icon>
       <n-icon :class="getMovementClass('north')" @click="move('north')"><NorthOutlined></NorthOutlined></n-icon>

--- a/src/components/side-menu/MoveControls.vue
+++ b/src/components/side-menu/MoveControls.vue
@@ -154,7 +154,7 @@ onKeydown((ev) => {
         move('northeast')
         break
       case 'KeyA':
-		move('west')
+	move('west')
         break
       case 'KeyX':
         enter()

--- a/src/components/side-menu/MoveControls.vue
+++ b/src/components/side-menu/MoveControls.vue
@@ -143,37 +143,40 @@ onKeydown((ev) => {
   }
 
   if (state.options.wasdMovement) {
-    if (ev.key == 'Q' || ev.key == 'q') {
-      move('northwest')
-      return true
-    } else if (ev.key == 'W' || ev.key == 'w') {
-      move('north')
-      return true
-    } else if (ev.key == 'E' || ev.key == 'e') {
-      move('northeast')
-      return true
-    } else if (ev.key == 'A' || ev.key == 'a') {
-      move('west')
-      return true
-    } else if (ev.key == 'X' || ev.key == 'x') {
-      enter()
-      return true
-    } else if (ev.key == 'D' || ev.key == 'd') {
-      move('east')
-      return true
-    } else if (ev.key == 'Z' || ev.key == 'z') {
-      move('southwest')
-      return true
-    } else if (ev.key == 'S' || ev.key == 's') {
-      move('south')
-      return true
-    } else if (ev.key == 'C' || ev.key == 'c') {
-      move('southeast')
-      return true
+    switch(ev.code) {
+      case 'KeyQ':
+        move('northwest')
+        break
+      case 'KeyW':
+        move('north')
+        break
+      case 'KeyE':
+        move('northeast')
+        break
+      case 'KeyA':
+		move('west')
+        break
+      case 'KeyX':
+        enter()
+        break
+      case 'KeyD':
+        move('east')
+        break
+      case 'KeyZ':
+        move('southwest')
+        break
+      case 'KeyS':
+        move('south')
+        break
+      case 'KeyC':
+        move('southeast')
+        break
+      default:
+        return false
     }
   }
 
-  return false
+  return true
 })
 
 </script>

--- a/src/components/side-menu/SideMenu.vue
+++ b/src/components/side-menu/SideMenu.vue
@@ -9,13 +9,13 @@
         <div class="map-actions">
           <MapActions v-show="!state.gameState.battle.active"></MapActions>
         </div>
-        <div class="map-area" v-show="!state.gameState.battle.active" v-if="state.options.showMapArea">
+	<div class="map-area" v-show="!state.gameState.battle.active">
           <MoveControls></MoveControls>
-          <div class="mid-buttons">
+          <div class="mid-buttons" v-if="state.options.showMapArea">
             <n-icon class="map-icon" v-on:click="toggleMap()"><MapOutlined /></n-icon>
             <n-button v-if="state.gameState.mercEid !== -1" ghost @click="toggleMercModal">Merc</n-button>
           </div>
-          <MiniMap></MiniMap>
+          <MiniMap v-if="state.options.showMapArea"></MiniMap>
         </div>
         <QuickStats :entity="state.gameState.player"></QuickStats>
       </div>


### PR DESCRIPTION
This sets the keybinds for movement so that it will work with the same keys indifferent of the user's layout. Also included here a fix for WASD or numpad buttons being disabled if hiding the map area from options.