### PR TITLE
Feat: toggle move controls in mobile menu

### DIFF
--- a/src/components/game-modal/OptionsPane.vue
+++ b/src/components/game-modal/OptionsPane.vue
@@ -26,6 +26,13 @@
             <NSwitch id="option-swap-menu-side" v-model:value="state.options.swapMobileMenuSide" aria-label="Swap Menu Side" class="selectable"></NSwitch>
           </div>
         </NGi>
+
+        <NGi>
+          <div class="option">
+            <label for="option-show-map-area">Show Movement Controls</label>
+            <NSwitch id="option-show-map-area" v-model:value="state.options.showMobileMenuMoveControls" aria-label="Show Movement Controls" class="selectable"></NSwitch>
+          </div>
+        </NGi>
       </NGrid>
 
       <NGrid class="options" cols="1">

--- a/src/components/mobile-menu/MobileMenu.vue
+++ b/src/components/mobile-menu/MobileMenu.vue
@@ -6,8 +6,8 @@
         <div class="quick-slots">
           <QuickSlots :layout-mode="'mobile'"></QuickSlots>
         </div>
-        <div class="map-area" v-show="!state.gameState.battle.active">
-          <MoveControls></MoveControls>
+        <div class="map-area" v-show="!state.gameState.battle.active && (state.options.showMobileMenuMoveControls || state.options.showMobileMenuMap)">
+          <MoveControls v-if="state.options.showMobileMenuMoveControls"></MoveControls>
           <MiniMap v-if="state.options.showMobileMenuMap"></MiniMap>
         </div>
         <div class="mini-stats">

--- a/src/components/mobile-menu/OptionsMenu.vue
+++ b/src/components/mobile-menu/OptionsMenu.vue
@@ -18,6 +18,11 @@
       <n-switch id="option-swap-menu-side" v-model:value="state.options.swapMobileMenuSide" aria-label="Swap Menu Side"></n-switch>
     </div>
 
+    <div class="option">
+      <label for="option-show-map-area">Show Movement Controls</label>
+      <n-switch id="option-show-map-area" v-model:value="state.options.showMobileMenuMoveControls" aria-label="Show Movement Controls"></n-switch>
+    </div>
+
     <h3>General</h3>
 
     <div class="option">

--- a/src/static/state.js
+++ b/src/static/state.js
@@ -188,6 +188,7 @@ function resetOptions () {
     showMobileMenuMap: true,
     fixedMobileMenuMap: false,
     swapMobileMenuSide: false,
+    showMobileMenuMoveControls: false,
 
     // map options
     sideMapWidth: 50,

--- a/src/static/state.js
+++ b/src/static/state.js
@@ -188,7 +188,7 @@ function resetOptions () {
     showMobileMenuMap: true,
     fixedMobileMenuMap: false,
     swapMobileMenuSide: false,
-    showMobileMenuMoveControls: false,
+    showMobileMenuMoveControls: true,
 
     // map options
     sideMapWidth: 50,


### PR DESCRIPTION
Add another checkbox in the options which lets you disable the movement controls in the mobile menu.

If both the movement controls and the map are turned off, the container disappears as well.