### PR TITLE
Fix: restrict default side map size to max in slider

### DIFF
--- a/src/static/state.js
+++ b/src/static/state.js
@@ -190,8 +190,8 @@ function resetOptions () {
     swapMobileMenuSide: false,
 
     // map options
-    sideMapWidth: 50,
-    sideMapHeight: 50,
+    sideMapWidth: 25,
+    sideMapHeight: 25,
 
     // interface options
     showMinimap: false,


### PR DESCRIPTION
Default is 50, max possible selected is 25