### PR TITLE
fix: missed small surplus condition in MoveControls

### DIFF
--- a/src/components/mobile-menu/MoveControls.vue
+++ b/src/components/mobile-menu/MoveControls.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="movement" v-if="state.options.showMobileMenuMap">
+  <div class="movement">
     <div class="row">
       <n-icon :class="getMovementClass('northwest')" @click="move('northwest')"><NorthWestOutlined></NorthWestOutlined></n-icon>
       <n-icon :class="getMovementClass('north')" @click="move('north')"><NorthOutlined></NorthOutlined></n-icon>


### PR DESCRIPTION
Missed something, it caused MoveControls to not appear unless MapArea was selected too