### PR TITLE
Feat: combat UI improvements

### DIFF
--- a/src/components/main-area/LineOutput.vue
+++ b/src/components/main-area/LineOutput.vue
@@ -286,7 +286,7 @@ function getOutputHeight () {
     heightOffset += 33
   }
 
-  if (state.options.showPartyStats) {
+  if (state.options.showPartyStats && !state.gameState.battle.active) {
     heightOffset += getPartyStatsHeight()
   }
 

--- a/src/components/main-area/SideAliases.vue
+++ b/src/components/main-area/SideAliases.vue
@@ -37,7 +37,7 @@ function getBottom () {
     bottomOffset += 56
   }
 
-  if (state.options.showPartyStats) {
+  if (state.options.showPartyStats && !state.gameState.battle.active) {
     bottomOffset += getPartyStatsHeight()
   }
 

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -27,7 +27,7 @@
       <OverworldHUD v-if="!state.gameState.battle.active"></OverworldHUD>
       <QuickSlots v-if="state.options.showQuickSlots"></QuickSlots>
       <QuickSlotHandlers></QuickSlotHandlers>
-      <PartyStats v-if="state.options.showPartyStats"></PartyStats>
+      <PartyStats v-if="state.options.showPartyStats && !state.gameState.battle.active"></PartyStats>
       <KeyboardInput :focus-mode="'input'" :active-modes="['hotkey', 'input']"></KeyboardInput>
 
     </n-layout>
@@ -110,7 +110,7 @@ function getSideAreaHeight () {
     heightOffset += 56
   }
 
-  if (state.options.showPartyStats) {
+  if (state.options.showPartyStats && !state.gameState.battle.active) {
     heightOffset += getPartyStatsHeight()
   }
 


### PR DESCRIPTION
- Disable PartyStatus HUD during combat
- Split combatants in rows of 3 (2 at mobile breakpoints)
- Properly order opposing combatants to face one another
- Remove duplicated code