### PR TITLE
Feat/combat UI improvements 2

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -135,6 +135,16 @@ body, html {
 #app {
   height: 100vh;
   font-size: 16px;
+
+  &.font-18 {
+    font-size: 18px;
+  }
+  &.font-16 {
+    font-size: 16px;
+  }
+  &.font-14 {
+    font-size: 14px;
+  }
 }
 
 .red, .ansi-red-fg { color: #c50f1f; }

--- a/src/components/battle/BattleEntity.vue
+++ b/src/components/battle/BattleEntity.vue
@@ -1,134 +1,83 @@
 <template>
-  <div :class="getClass(participant)" @click="target(participant)">
+  <div class="battle-entity" :class="getClass" @click="target(participant)">
     <div class="name-area">
-      <div class="name-affects">
-        <div class="name">
-          <div v-html-safe="ansiToHtml(`${participant.hpPercent > 0 ? participant.tag + ' ' : ''}L${ANSI.boldWhite}${participant.level} ${participant.name}`)"></div>
+      <div class="name-merc-col">
+        <div class="name-row" lang="en"
+             v-html-safe="ansiToHtml(`${participant.hpPercent > 0 ? participant.tag + ' ' : ''}L${ANSI.boldWhite}${participant.level} ${participant.name}`)">
         </div>
-        
-        <div class="affects-row">
-          <div class="affects" v-html-safe="ansiToHtml(getAffects(participant))"></div>
+        <MercOrders :merc="getMercenary(entity)" v-if="isMercenary(entity)"></MercOrders>
+      </div>
+
+      <div class="affect-area">
+        <div class="affect-row">
+          <span class="affect" v-for="affect in getAffects(participant)" v-html-safe="affect"/>
         </div>
-
-        <div class="affects-row">
-          <div class="target">
-            <div v-if="participant.targetName" v-html-safe="ansiToHtml(`Target: ${participant.targetName}`)"></div>
-          </div>
-          <div class="combo-rage" v-if="side == 'good'">
-            <div class="affect" v-if="entity && entity.combo > 0">
-              <div class="amount bold-yellow">{{ entity.combo }}</div>
-              <div class="label yellow">Combo</div>
-            </div>
-
-            <div class="affect" v-if="entity && entity.rage > 0">
-              <div class="amount bold-red">{{ entity.rage }}</div>
-              <div class="label red">Rage</div>
-            </div>
-          </div>
+        <div class="bonus-row">
+        <span class="affect affect-back" v-if="side === 'good' && entity && entity.combo > 0">
+                <span class="amount bold-yellow">{{ entity.combo }}</span> <span class="label yellow">Combo</span>
+              </span>
+          <span class="affect affect-back" v-if="side === 'good' && entity && entity.rage > 0">
+                <span class="amount bold-red">{{ entity.rage }}</span> <span class="label red">Rage</span>
+              </span>
         </div>
       </div>
 
-      <MercOrders :merc="getMercenary(entity)" v-if="isMercenary(entity)"></MercOrders>
-
+      <div class="target-row">
+        <div v-if="participant.targetName" v-html-safe="ansiToHtml(`Target: ${getTarget(participant)}`)"></div>
+      </div>
     </div>
 
-    <div class="vital-row">
-      <div class="vital-amount bold-green" v-if="entity && side == 'good'">
-        {{ entity.hp }}
+    <div class="vital-area">
+      <div class="vital-row">
+        <div class="vital-amount bold-green">
+          {{ entity && side === 'good' ? entity.hp : `${participant.hpPercent}%` }}
+        </div>
+
+        <NProgress
+            class="vital-bar" type="line" status="success" aria-label="Health"
+            :stroke-width="16"
+            :percentage="entity && side === 'good' ? entity.hp / entity.maxHp * 100 : participant.hpPercent"
+            :show-indicator="false"
+            :border-radius="0"
+            :height="10"
+        ></NProgress>
       </div>
 
-      <div class="vital-amount bold-green" v-if="side == 'evil'">
-        {{ participant.hpPercent }}%
+      <div class="vital-row">
+        <div class="vital-amount bold-cyan">
+          {{ entity && side === 'good' ? entity.energy : `${participant.energyPercent}%` }}
+        </div>
+
+        <NProgress
+            class="vital-bar" type="line" status="default" aria-label="Energy"
+            :stroke-width="16"
+            :percentage="entity && side === 'good' ? entity.energy / entity.maxEnergy * 100 : participant.energyPercent"
+            :show-indicator="false"
+            :border-radius="0"
+            :height="10"
+        ></NProgress>
       </div>
 
-      <NProgress
-        class="vital-bar" type="line" status="success" aria-label="Health"
-        v-if="entity && side == 'good'"
-        :stroke-width="16"
-        :percentage="entity.hp / entity.maxHp * 100"
-        :show-indicator="false"
-        :border-radius="0"
-        :height="10"
-      ></NProgress>
+      <div class="vital-row">
+        <div class="vital-amount bold-yellow">
+          {{ entity && side === 'good' ? entity.stamina : `${participant.staminaPercent}%` }}
+        </div>
 
-      <NProgress
-        class="vital-bar" type="line" status="success" aria-label="Health"
-        v-if="side == 'evil'"
-        :stroke-width="16"
-        :percentage="participant.hpPercent"
-        :show-indicator="false"
-        :border-radius="0"
-        :height="10"
-      ></NProgress>
+        <NProgress
+            class="vital-bar" type="line" status="warning" aria-label="Stamina"
+            :stroke-width="16"
+            :percentage="entity && side === 'good' ? entity.stamina / entity.maxStamina * 100 : participant.staminaPercent"
+            :show-indicator="false"
+            :border-radius="0"
+            :height="10"
+        ></NProgress>
+      </div>
     </div>
-
-    <div class="vital-row">
-      <div class="vital-amount bold-cyan" v-if="entity && side == 'good'">
-        {{ entity.energy }}
-      </div>
-
-      <div class="vital-amount bold-cyan" v-if="side == 'evil'">
-        {{ participant.energyPercent }}%
-      </div>
-
-      <NProgress
-        class="vital-bar" type="line" status="default" aria-label="Health"
-        v-if="entity && side == 'good'"
-        :stroke-width="16"
-        :percentage="entity.energy / entity.maxEnergy * 100"
-        :show-indicator="false"
-        :border-radius="0"
-        :height="10"
-      ></NProgress>
-
-      <NProgress
-        class="vital-bar" type="line" status="default" aria-label="Health"
-        v-if="side == 'evil'"
-        :stroke-width="16"
-        :percentage="participant.energyPercent"
-        :show-indicator="false"
-        :border-radius="0"
-        :height="10"
-      ></NProgress>
-    </div>
-
-
-    <div class="vital-row">
-      <div class="vital-amount bold-yellow" v-if="entity && side == 'good'">
-        {{ entity.stamina }}
-      </div>
-
-      <div class="vital-amount bold-yellow" v-if="side == 'evil'">
-        {{ participant.staminaPercent }}%
-      </div>
-
-      <NProgress
-        class="vital-bar" type="line" status="warning" aria-label="Stamina"
-        v-if="entity && side == 'good'"
-        :stroke-width="16"
-        :percentage="entity.stamina / entity.maxStamina * 100"
-        :show-indicator="false"
-        :border-radius="0"
-        :height="10"
-      ></NProgress>
-
-      <NProgress
-        class="vital-bar" type="line" status="warning" aria-label="Stamina"
-        v-if="side == 'evil'"
-        :stroke-width="16"
-        :percentage="participant.staminaPercent"
-        :show-indicator="false"
-        :border-radius="0"
-        :height="10"
-      ></NProgress>
-    </div>
-
-
   </div>
 
 </template>
 <script setup>
-import { defineProps, toRefs } from 'vue'
+import { defineProps, toRefs, computed, reactive } from 'vue'
 import { NProgress } from 'naive-ui'
 import stripAnsi from 'strip-ansi'
 
@@ -145,7 +94,7 @@ const { cmd } = useWebSocket()
 const props = defineProps({
   participant: Object,
   entity: Object,
-  side: String
+  side: String,
 })
 
 const { participant, entity, side } = toRefs(props)
@@ -155,24 +104,47 @@ function target (participant) {
   cmd(`target ${stripAnsi(participant.tag)}`)
 }
 
-function getClass (participant) {
-  return [
-    'battle-entity',
-    'selectable',
-    participant.hpPercent == 0 ? 'dead' : participant.side,
-    participant.isActing ? 'acting' : '',
-    state.options.showMobileMenu ? 'mobile-menu-open' : ''
-  ].join(' ')
+const isPlayerTarget = (participant) => {
+  const player = Object.values(state.gameState.battle.participants).find(p => p.eid === state.gameState.player.eid)
+  if (!player || !player.targetName) return false
+  if (!participant.tag) return false
+  if (player.eid === participant.eid) return stripAnsi(player.targetName) === 'You'
+  return stripAnsi(participant.tag) === stripAnsi(player.targetName)
 }
 
+const isTargetingPlayer = (participant) => {
+  console.debug(state)
+  if (!participant.targetName) return false
+  const name = stripAnsi(participant.targetName)
+  return name === 'You'
+}
+
+const getClass = computed(() => {
+  console.debug(side.value)
+  return {
+    'dead': participant.value.hpPercent === 0,
+    'selectable': participant.value.hpPercent > 0,
+    'good': side.value === 'good' && participant.value.hpPercent > 0,
+    'evil': side.value === 'evil' && participant.value.hpPercent > 0,
+    'merc': isMercenary(entity.value),
+    'acting': participant.value.isActing,
+    'selected': isPlayerTarget(participant.value),
+    'targeting-you': isTargetingPlayer(participant.value),
+    'mobile-menu-open': state.options.showMobileMenu,
+  }
+})
+
 function getAffects (participant) {
-  if (participant.hpPercent == 0) {
-    return ANSI.boldRed + 'DEAD' + ANSI.reset
+  let affects = []
+  if (participant.hpPercent <= 0) {
+    affects.push(ANSI.boldRed + 'DEAD' + ANSI.reset)
   }
-  if (participant.affects.length == 0) {
-    return ''
-  }
-  return participant.affects.join(' ')
+
+  affects = affects.concat(participant.affects)
+  console.debug(affects.map(s => ansiToHtml(s)))
+  affects = affects.map(s => ansiToHtml(s))
+
+  return affects
 }
 
 function isMercenary (entity) {
@@ -181,6 +153,13 @@ function isMercenary (entity) {
 
 function getMercenary (entity) {
   return state.gameState.charmies[entity.eid]
+}
+
+function getTarget (participant) {
+  if (!participant.targetName) return false
+  const target = Object.values(state.gameState.battle.participants).
+      find(p => stripAnsi(p.tag) === stripAnsi(participant.targetName))
+  return target ? `${target.tag} ${target.name}` : participant.targetName
 }
 
 // function getStatus (participant) {
@@ -199,23 +178,175 @@ function getMercenary (entity) {
 </script>
 <style lang="less" scoped>
 .battle-entity {
+  position: relative;
+  box-sizing: border-box;
+  height: 100%;
   display: flex;
+  align-self: stretch;
   flex-direction: column;
   justify-content: space-between;
   background-color: #462233;
-  padding: 5px;
+  padding: 6px 8px;
   border: 2px solid #333;
-  margin: 2px;
+  margin: 0;
   width: 250px;
-  
+
+  .name-area {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+
+    .name-affects-col {
+      width: 100%;
+    }
+
+    .name-row {
+      min-height: 36px;
+      -webkit-hyphens: auto;
+      -moz-hyphens: auto;
+      -ms-hyphens: auto;
+      hyphens: auto;
+      word-break: auto-phrase;
+    }
+
+    .name-merc-col {
+      display: flex;
+      flex-direction: row;
+    }
+
+    .affect-area {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 15px;
+      margin: 0 0 6px;
+    }
+
+    .affect-row {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      gap: 4px 4px;
+      flex-grow: 1;
+      justify-content: flex-start;
+    }
+
+    .bonus-row {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      gap: 4px 8px;
+      justify-content: flex-end;
+    }
+
+    .affect {
+      text-wrap: nowrap;
+      padding: 2px 6px;
+      background: rgba(black, 0.2);
+      display: flex;
+      gap: 4px;
+    }
+  }
+
+  .order-dropdown {
+    margin-left: 5px;
+  }
+
+  .target-row {
+    min-height: 36px;
+  }
+
+  .vital-area {
+    padding: 2px 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    background: rgba(black, 0.2);
+  }
+
+  .vital-row {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    padding-right: 5px;
+
+    .vital-amount {
+      width: 50px;
+      text-align: right;
+      padding-right: 5px;
+      line-height: 1;
+    }
+  }
+
+  &::before {
+    transition: border-color 0.3s;
+    content: '';
+    position: absolute;
+    width: 0;
+    top: -9999px;
+    left: -9999px;
+    height: 0;
+    border-style: solid;
+    border-width: 15px 15px 15px 15px;
+    border-color: transparent transparent transparent transparent;
+    transform: rotate(0deg);
+  }
+
+  &::after {
+    transition: border-color 0.3s;
+    content: '';
+    position: absolute;
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 15px 15px 15px 15px;
+    border-color: transparent transparent transparent transparent;
+    transform: rotate(0deg);
+  }
+
+  &.selectable {
+    cursor: pointer;
+  }
+
   &.selected {
-    // border: 1px solid #f8ff25;
+    //box-shadow: none;
+    //border: 1px solid #f8ff25;
     box-shadow: 0 0 5px #f8ff25 !important;
     color: #f8ff25 !important;
+
+    &::before {
+      top: auto;
+      bottom: -2px;
+      left: -2px;
+      border-width: 15px 0 0 15px;
+      border-color: transparent transparent transparent #909317;
+    }
+  }
+
+  &.targeting-you {
+    border-color: #ffa850;
+    box-shadow: 0 0 5px #ffa850;
+
+    &::after {
+      top: -2px;
+      left: auto;
+      right: -2px;
+      border-width: 0 15px 15px 0;
+      border-color: transparent #ffa850 transparent transparent;
+    }
+  }
+
+  &.acting {
+    &::after {
+      top: 0;
+      left: auto;
+      right: 0;
+    }
   }
 
   &.good {
-    cursor: pointer;
     background-color: #001800;
     border-color: #001800;
 
@@ -229,10 +360,15 @@ function getMercenary (entity) {
     &.acting {
       border-color: #50ff50;
       box-shadow: 0 0 5px #50ff50;
+
+      &::after {
+        border-width: 0 15px 15px 0;
+        border-color: transparent #50ff50 transparent transparent;
+      }
     }
   }
+
   &.evil {
-    cursor: pointer;
     background-color: #180000;
     border-color: #180000;
 
@@ -246,92 +382,20 @@ function getMercenary (entity) {
     &.acting {
       border-color: #ff5050;
       box-shadow: 0 0 5px #ff5050;
-    }
-  }
 
-  .name-area {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    min-height: 70px;
-
-    .name-affects {
-      width: 100%;
-
-      .affects-row {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-
-        .combo-rage {
-          .affect {
-            display: flex;
-            flex-direction: row;
-            justify-content: flex-end;
-            align-items: center;
-            gap: 5px;
-          }
-        }
+      &::after {
+        border-width: 0 15px 15px 0;
+        border-color: transparent #ff5050 transparent transparent;
       }
     }
   }
 
-  .vital-row {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-    gap: 5px;
-    padding-right: 15px;
-    .vital-amount {
-      width: 50px;
-      text-align: right;
+}
+@media screen and (min-width: 801px) and (max-width: 1075px) {
+  .battle-status.mobile-menu-open {
+    .battle-entity {
+      width: 200px;
     }
-  }
-
-  .vitals {
-    display: flex;
-    flex-direction: row;
-    .vital {
-      width: 40px;
-      padding: 0 5px 0 0;
-      line-height: 16px;
-      text-align: center;
-      .label {
-        font-size: 10px;
-        line-height: 4px;
-      }
-    }
-  }
-}
-
-@media screen and (max-width: 1575px) {
-  .battle-entity.mobile-menu-open {
-    width: 230px;
-  }
-}
-
-@media screen and (max-width: 1375px) {
-  .battle-entity.mobile-menu-open {
-    width: 220px;
-  }
-}
-
-@media screen and (max-width: 1300px) {
-  .battle-entity {
-    width: 210px;
-  }
-}
-
-@media screen and (max-width: 1100px) {
-  .battle-entity {
-    width: 200px;
-  }
-}
-
-@media screen and (max-width: 400px) {
-  .battle-entity {
-    width: 250px;
   }
 }
 

--- a/src/components/battle/BattleEntity.vue
+++ b/src/components/battle/BattleEntity.vue
@@ -22,12 +22,12 @@
         </div>
       </div>
 
-      <div class="target-row">
+      <div class="target-row" v-if="participant.hpPercent > 0">
         <div v-if="participant.targetName" v-html-safe="ansiToHtml(`Target: ${getTarget(participant)}`)"></div>
       </div>
     </div>
 
-    <div class="vital-area">
+    <div class="vital-area" v-if="participant.hpPercent > 0">
       <div class="vital-row">
         <div class="vital-amount bold-green">
           {{ entity && side === 'good' ? entity.hp : `${participant.hpPercent}%` }}
@@ -113,14 +113,12 @@ const isPlayerTarget = (participant) => {
 }
 
 const isTargetingPlayer = (participant) => {
-  console.debug(state)
   if (!participant.targetName) return false
   const name = stripAnsi(participant.targetName)
   return name === 'You'
 }
 
 const getClass = computed(() => {
-  console.debug(side.value)
   return {
     'dead': participant.value.hpPercent === 0,
     'selectable': participant.value.hpPercent > 0,
@@ -141,7 +139,6 @@ function getAffects (participant) {
   }
 
   affects = affects.concat(participant.affects)
-  console.debug(affects.map(s => ansiToHtml(s)))
   affects = affects.map(s => ansiToHtml(s))
 
   return affects
@@ -215,7 +212,6 @@ function getTarget (participant) {
       justify-content: space-between;
       align-items: flex-start;
       gap: 15px;
-      margin: 0 0 6px;
     }
 
     .affect-row {
@@ -250,6 +246,7 @@ function getTarget (participant) {
 
   .target-row {
     min-height: 36px;
+    margin: 6px 0 0;
   }
 
   .vital-area {

--- a/src/components/battle/BattleEntity.vue
+++ b/src/components/battle/BattleEntity.vue
@@ -202,11 +202,6 @@ function getTarget (participant) {
 
     .name-row {
       min-height: 36px;
-      -webkit-hyphens: auto;
-      -moz-hyphens: auto;
-      -ms-hyphens: auto;
-      hyphens: auto;
-      word-break: auto-phrase;
     }
 
     .name-merc-col {
@@ -281,12 +276,9 @@ function getTarget (participant) {
   }
 
   &::before {
-    transition: border-color 0.3s;
     content: '';
     position: absolute;
     width: 0;
-    top: -9999px;
-    left: -9999px;
     height: 0;
     border-style: solid;
     border-width: 15px 15px 15px 15px;
@@ -295,7 +287,6 @@ function getTarget (participant) {
   }
 
   &::after {
-    transition: border-color 0.3s;
     content: '';
     position: absolute;
     width: 0;
@@ -317,7 +308,6 @@ function getTarget (participant) {
     color: #f8ff25 !important;
 
     &::before {
-      top: auto;
       bottom: -2px;
       left: -2px;
       border-width: 15px 0 0 15px;
@@ -331,7 +321,6 @@ function getTarget (participant) {
 
     &::after {
       top: -2px;
-      left: auto;
       right: -2px;
       border-width: 0 15px 15px 0;
       border-color: transparent #ffa850 transparent transparent;
@@ -341,7 +330,6 @@ function getTarget (participant) {
   &.acting {
     &::after {
       top: 0;
-      left: auto;
       right: 0;
     }
   }

--- a/src/components/battle/BattleStatus.vue
+++ b/src/components/battle/BattleStatus.vue
@@ -64,6 +64,7 @@ function getBattleStatusClass () {
 }
 
 function getParticipants (side) {
+  console.debug(side, Object.values(state.gameState.battle.participants).filter(p => p.side == side))
   return Object.values(state.gameState.battle.participants).filter(p => p.side == side)
 }
 
@@ -90,10 +91,9 @@ function getRows (side) {
   const perRow = getParticipantsPerRow();
 
   const len = getParticipants(side).length
-  const rest = len % perRow
-  const lenMinusRest = len - rest
-  const rows = lenMinusRest / perRow
+  const rows = Math.ceil(len / perRow)
 
+  console.debug(side, rows)
   return Math.max(1, rows) // To ward off against 3 participants returning 0 rows.
 }
 

--- a/src/components/battle/BattleStatus.vue
+++ b/src/components/battle/BattleStatus.vue
@@ -24,7 +24,7 @@
                 >{{ anim.amount }}</div>
               </TransitionGroup>
 
-              <BattleEntity :entity="getPartyEntity(participant)" :participant="participant" :side="'good'"></BattleEntity>
+              <BattleEntity :entity="getPartyEntity(participant)" :participant="participant" :side="side"></BattleEntity>
             </div>
           </div>
         </div>
@@ -144,8 +144,22 @@ onBeforeUnmount(() => {
   .vs {
     flex-basis: 4%;
     font-size: 1.1rem;
-    color: #c50f1f;
     text-align: center;
+    font-weight: bold;
+    //color: #c50f1f;
+    color: #f5f5f5;
+    text-shadow:
+          0px -2px 2px black,
+          2px 0px 2px black,
+          -2px 0px 2px black,
+          0px -4px 4px #fff,
+          0px -4px 4px #fff,
+      0px -6px 6px #FF3,
+      0px -6px 6px #FF3,
+      0px -8px 8px #F90,
+      0px -8px 8px #F90,
+      0px -16px 12px #C33,
+      0px -16px 12px #C33;
   }
 
   .side {
@@ -159,8 +173,9 @@ onBeforeUnmount(() => {
       justify-content: center;
 
       .entity {
+        align-self: stretch;
         position: relative;
-        margin-bottom: 5px;
+        margin: 5px;
 
         .damage {
           opacity: 0;

--- a/src/components/battle/BattleStatus.vue
+++ b/src/components/battle/BattleStatus.vue
@@ -142,6 +142,7 @@ onBeforeUnmount(() => {
   align-items: center;
 
   .vs {
+    animation: vs 0.6s ease-out;
     flex-basis: 4%;
     font-size: 1.1rem;
     text-align: center;
@@ -178,14 +179,14 @@ onBeforeUnmount(() => {
         margin: 5px;
 
         .damage {
-          opacity: 0;
           position: absolute;
-          top: 0px;
+          top: 0;
           font-size: 1.4rem;
           color: #ff3333;
           padding: 5px 10px;
           opacity: 0.8;
           background-color: #101014;
+          z-index: 1;
 
           &.crit {
             line-height: 1.2rem;
@@ -196,13 +197,13 @@ onBeforeUnmount(() => {
 
         .healing {
           position: absolute;
-          opacity: 0;
           top: -40px;
           font-size: 1.4rem;
           color: #33ff33;
           padding: 5px 10px;
           opacity: 0.8;
           background-color: #101014;
+          z-index: 1;
         }
       }
     }
@@ -231,7 +232,7 @@ onBeforeUnmount(() => {
 @keyframes damage {
   0% {
     opacity: 1;
-    top: 0px;
+    top: 0;
   }
   60% {
     opacity: 0.9;
@@ -258,7 +259,22 @@ onBeforeUnmount(() => {
   }
   100% {
     opacity: 0;
-    top: 0px;
+    top: 0;
+  }
+}
+
+@keyframes vs {
+  0% {
+    rotate: 20deg;
+    scale: 600%;
+  }
+  80% {
+    scale: 90%;
+    rotate: -10deg;
+  }
+  100% {
+    rotate: 0deg;
+    scale: 100%;
   }
 }
 

--- a/src/components/battle/MercOrders.vue
+++ b/src/components/battle/MercOrders.vue
@@ -108,8 +108,4 @@ async function setOptions () {
 
 </script>
 
-<style lang="less" scoped>
-.order-dropdown {
-  margin-top: 5px;
-}
-</style>
+<style lang="less" scoped />

--- a/src/components/main-area/LineOutput.vue
+++ b/src/components/main-area/LineOutput.vue
@@ -286,7 +286,7 @@ function getOutputHeight () {
     heightOffset += 33
   }
 
-  if (state.options.showPartyStats) {
+  if (state.options.showPartyStats && !state.gameState.battle.active) {
     heightOffset += getPartyStatsHeight()
   }
 

--- a/src/components/main-area/SideAliases.vue
+++ b/src/components/main-area/SideAliases.vue
@@ -37,7 +37,7 @@ function getBottom () {
     bottomOffset += 56
   }
 
-  if (state.options.showPartyStats) {
+  if (state.options.showPartyStats && !state.gameState.battle.active) {
     bottomOffset += getPartyStatsHeight()
   }
 

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -27,7 +27,7 @@
       <OverworldHUD v-if="!state.gameState.battle.active"></OverworldHUD>
       <QuickSlots v-if="state.options.showQuickSlots"></QuickSlots>
       <QuickSlotHandlers></QuickSlotHandlers>
-      <PartyStats v-if="state.options.showPartyStats"></PartyStats>
+      <PartyStats v-if="state.options.showPartyStats && !state.gameState.battle.active"></PartyStats>
       <KeyboardInput :focus-mode="'input'" :active-modes="['hotkey', 'input']"></KeyboardInput>
 
     </n-layout>
@@ -110,7 +110,7 @@ function getSideAreaHeight () {
     heightOffset += 56
   }
 
-  if (state.options.showPartyStats) {
+  if (state.options.showPartyStats && !state.gameState.battle.active) {
     heightOffset += getPartyStatsHeight()
   }
 


### PR DESCRIPTION
- Disable PartyStatus HUD during combat
- Split combatants in rows of 3 (2 at mobile breakpoints)
- Properly order opposing combatants to face one another
- Code duplication cleanup
- Clean up BattleEntity styling
- Add "selected" and "targeting you" highlights
- Nicer highlight visuals
- Nicer affect list
- Use full name of targets
- PartyStats hidden during combat
- Fancy "VS."
- Compact DEAD combatants