### PR TITLE
Fix: do not clear options and mappings on disconnect

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -135,16 +135,6 @@ body, html {
 #app {
   height: 100vh;
   font-size: 16px;
-
-  &.font-18 {
-    font-size: 18px;
-  }
-  &.font-16 {
-    font-size: 16px;
-  }
-  &.font-14 {
-    font-size: 14px;
-  }
 }
 
 .red, .ansi-red-fg { color: #c50f1f; }

--- a/src/components/battle/BattleStatus.vue
+++ b/src/components/battle/BattleStatus.vue
@@ -94,7 +94,6 @@ function getRows (side) {
   const len = getParticipants(side).length
   const rows = Math.ceil(len / perRow)
 
-  console.debug(side, rows)
   return Math.max(1, rows) // To ward off against 3 participants returning 0 rows.
 }
 

--- a/src/static/state.js
+++ b/src/static/state.js
@@ -116,10 +116,10 @@ export function resetState () {
   state.mode = 'hotkey'
   state.prevModes = ['login']
   state.pendingRequests = {}
-  state.inputMappings = resetInputMappings()
   state.cache = resetCache()
   state.gameState = resetGameState()
-  state.options = resetOptions()
+  // state.inputMappings = resetInputMappings()
+  // state.options = resetOptions() // Do not reset the GUI on reconnect
   state.output = []
   state.chat = []
   state.trade = []
@@ -217,6 +217,7 @@ function resetOptions () {
 }
 
 export function authenticationSuccess ({ name, token }) {
+  console.debug("authSuccess");
   state.name = name
   state.token = token
   state.disconnected = false


### PR DESCRIPTION
This would cause the GUI and player options to be reset when reconnecting after a disconnect or quit.