### PR TITLE
feat: Maintain terminal size on login

### DIFF
--- a/src/components/SplashScreen.vue
+++ b/src/components/SplashScreen.vue
@@ -72,7 +72,11 @@ let tokens = ref([])
 
 async function doTokenAuth (name, token) {
   let { cmd, msg } = await sendWithResponse('token', {
-    name, token, width: 70, height: 24, ttype: 'play.proceduralrealms.com'
+    name,
+    token,
+    width: state.options.terminalWidth,
+    height: state.options.terminalHeight,
+    ttype: 'play.proceduralrealms.com'
   })
 
   if (cmd == 'login.validationFailed') {

--- a/src/components/modals/LoginModal.vue
+++ b/src/components/modals/LoginModal.vue
@@ -87,8 +87,8 @@ const rules = {
           let { cmd, msg } = await sendWithResponse('login', {
             name: model.value.name,
             password: model.value.password,
-            width: 100,
-            height: 24,
+            width: state.options.terminalWidth,
+            height: state.options.terminalHeight,
             ttype: 'play.proceduralrealms.com'
           })
 

--- a/src/components/modals/NewPlayerModal.vue
+++ b/src/components/modals/NewPlayerModal.vue
@@ -138,8 +138,8 @@ const rules = {
           let { cmd, msg } = await sendWithResponse('create', {
             name: model.value.name,
             password: model.value.password,
-            width: 100,
-            height: 24,
+            width: state.options.terminalWidth,
+            height: state.options.terminalHeight,
             tutorial: model.value?.tutorial ? 'Y' : 'N',
             ttype: 'play.proceduralrealms.com'
           })

--- a/src/composables/window_handler.js
+++ b/src/composables/window_handler.js
@@ -19,12 +19,12 @@ export function useWindowHandler () {
   function calcTerminalSize (outputWidth, outputHeight) {
     let output = document.getElementById('output')
     if (!output) {
-      return { width: 80, height: 25 }
+      return DEFAULT_TERMINAL_SIZE
     }
 
     let outputLine = output.querySelector('.line')
     if (!outputLine) {
-      return { width: 80, height: 25 }
+      return DEFAULT_TERMINAL_SIZE
     }
 
     let outputStyle = getComputedStyle(outputLine)
@@ -39,6 +39,8 @@ export function useWindowHandler () {
     let width = Math.floor(outputWidth  / charWidth)
     let height = Math.floor(outputHeight  / charHeight)
 
+    state.options.terminalWidth = width;
+    state.options.terminalHeight = height;
     return { width, height }
   }
 

--- a/src/static/constants.js
+++ b/src/static/constants.js
@@ -725,3 +725,8 @@ export const MUSIC_TRACKS = [{
   name: 'Whispers of the Wild',
   url: '/music/Whispers of the Wild.mp3',
 }]
+
+export const DEFAULT_TERMINAL_SIZE = {
+  width: 80,
+  height: 25,
+}

--- a/src/static/state.js
+++ b/src/static/state.js
@@ -4,6 +4,7 @@ import { EventEmitter } from 'events'
 import { loadSettingsByNameAndType } from '@/static/triggers'
 
 import { useLocalStorageHandler } from '@/composables/local_storage_handler'
+import { DEFAULT_TERMINAL_SIZE } from '@/static/constants.js'
 
 const { addToken } = useLocalStorageHandler()
 
@@ -213,11 +214,14 @@ function resetOptions () {
     // font options
     fontFamily: 'Ubuntu Mono, monospace',
     fontSize: '16px',
+
+    // terminal size
+    terminalWidth: DEFAULT_TERMINAL_SIZE.width,
+    terminalHeight: DEFAULT_TERMINAL_SIZE.height,
   }
 }
 
 export function authenticationSuccess ({ name, token }) {
-  console.debug("authSuccess");
   state.name = name
   state.token = token
   state.disconnected = false


### PR DESCRIPTION
Saves last known window size in options and uses it in the token packet
Also centrailze "default terminal size" in a constant instead of having sizes scattered around the files