### PR TITLE
Fix for overflowing and font issue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -120,6 +120,7 @@ body, html {
   font-family: 'Ubuntu Mono', monospace;
   color: #fff;
   overflow-x: hidden;
+  overflow-y: hidden;
   color-scheme: dark;
   line-height: 1.1;
   -webkit-font-smoothing: antialiased;

--- a/src/components/game-modal/OptionsPane.vue
+++ b/src/components/game-modal/OptionsPane.vue
@@ -151,7 +151,7 @@ function onSetFontSize () {
 }
 
 function onSetFontFamily () {
-  setFontFamily(selectedFontFamily.value)
+  setFontFamily(state.options.fontFamily)
 }
 
 function openTriggersModal () {

--- a/src/composables/window_handler.js
+++ b/src/composables/window_handler.js
@@ -58,6 +58,7 @@ export function useWindowHandler () {
 
   function setFontFamily (fontFamily) {
     state.options.fontFamily = fontFamily
+    document.body.style.fontFamily = fontFamily;
     document.getElementById('app').style.fontFamily = fontFamily
 
     let modalContainers = document.getElementsByClassName('n-modal-container')


### PR DESCRIPTION
Fixing a font consistency issue regarding the inventory modal popup. Because `naiveUI` renders modals just under body, the font family which is being applied to `#app` has no effect on that popup, so by setting it at the body level as well will have this effect. 

Screenshot of the bug:

![image](https://github.com/dinchak/procrealms-web-client/assets/11844042/1f951f15-aa6c-4125-a8df-36e7d2a9c924)

Looks like on the latest `master`, font selection does not work from the options pane. Addressing that as well.

For some reason (no idea why specifically) we run into overflow y issue and the whole thing can be scrolled down a bunch. I suspect that the side menu with fixed minimap is the root cause here. Either way, a quick and dirty `overflow-y: hidden;` solves that.