### PR TITLE
chore: quickslots styling/code cleanup

### DIFF
--- a/src/components/hud/QuickSlots.vue
+++ b/src/components/hud/QuickSlots.vue
@@ -1,73 +1,71 @@
 <template>
   <div :class="'quick-container' + getMobileLayoutClass()">
-    <div :class="'quick-actions'  + getMobileLayoutClass()">
-
-      <div :class="getAttackButtonClass()" v-if="state.gameState.battle.active" @click="cmd('attack')">
-        <div class="slot-label" v-if="getAttackButtonClass().includes('active')">
-          <span class="bold-yellow">A</span><span class="bold-red">ttack</span>
-        </div>
-        <div class="slot-label" v-else>
-          <span class="white">A</span><span class="bold-black">ttack</span>
-        </div>
-        <img v-if="isGamepadConnected()" src="@/assets/icons/xbox/x.png" class="icon" />
+    <div :class="getAttackButtonClass()" v-if="state.gameState.battle.active" @click="conditionalCmd(isAttackButtonActive, 'attack')">
+      <div class="slot-label" v-if="isAttackButtonActive()">
+        <span class="bold-yellow">A</span><span class="bold-red">ttack</span>
       </div>
-
-      <div :class="getDefendButtonClass()" v-if="state.gameState.battle.active" @click="cmd('defend')">
-        <div class="slot-label" v-if="getDefendButtonClass().includes('active')">
-          <span class="bold-yellow">D</span><span class="bold-cyan">efend</span>
-        </div>
-        <div class="slot-label" v-else>
-          <span class="white">D</span><span class="bold-black">efend</span>
-        </div>
-        <img v-if="isGamepadConnected()" src="@/assets/icons/xbox/y.png" class="icon" />
+      <div class="slot-label" v-else>
+        <span class="white">A</span><span class="bold-black">ttack</span>
       </div>
+      <img v-if="isGamepadConnected()" src="@/assets/icons/xbox/x.png" class="icon"/>
+    </div>
 
-      <div :class="getFleeButtonClass()" v-if="state.gameState.battle.active" @click="cmd('flee')">
-        <div class="slot-label" v-if="getFleeButtonClass().includes('active')">
-          <span class="bold-yellow">F</span><span class="yellow">lee</span>
-        </div>
-        <div class="slot-label" v-else>
-          <span class="white">F</span><span class="bold-black">lee</span>
-        </div>
-        <img v-if="isGamepadConnected()" src="@/assets/icons/xbox/b.png" class="icon" />
+    <div :class="getDefendButtonClass()" v-if="state.gameState.battle.active" @click="conditionalCmd(isDefendButtonActive, 'defend')">
+      <div class="slot-label" v-if="isDefendButtonActive()">
+        <span class="bold-yellow">D</span><span class="bold-cyan">efend</span>
       </div>
-
-      <div :class="getBattleButtonClass()" v-if="!state.gameState.battle.active" @click="cmd('battle')">
-        <div class="slot-label" v-if="getBattleButtonClass().includes('active')">
-          <span class="bold-yellow">B</span><span class="bold-red">attle</span>
-        </div>
-        <div class="slot-label" v-else>
-          <span class="white">B</span><span class="bold-black">attle</span>
-        </div>
-        <img v-if="isGamepadConnected()" src="@/assets/icons/xbox/x.png" class="icon" />
+      <div class="slot-label" v-else>
+        <span class="white">D</span><span class="bold-black">efend</span>
       </div>
+      <img v-if="isGamepadConnected()" src="@/assets/icons/xbox/y.png" class="icon"/>
+    </div>
 
-      <div :class="getHarvestButtonClass()" v-if="!state.gameState.battle.active" @click="cmd('harvest')">
-        <div class="slot-label" v-if="getHarvestButtonClass().includes('active')">
-          <span class="bold-yellow">H</span><span class="yellow">arvest</span>
-        </div>
-        <div class="slot-label" v-else>
-          <span class="white">H</span><span class="bold-black">arvest</span>
-        </div>
-        <img v-if="isGamepadConnected()" src="@/assets/icons/xbox/y.png" class="icon" />
+    <div :class="getFleeButtonClass()" v-if="state.gameState.battle.active" @click="conditionalCmd(isFleeButtonActive,'flee')">
+      <div class="slot-label" v-if="isFleeButtonActive()">
+        <span class="bold-yellow">F</span><span class="yellow">lee</span>
       </div>
-
-      <div :class="getLootButtonClass()" v-if="!state.gameState.battle.active" @click="cmd('loot')">
-        <div class="slot-label" v-if="getLootButtonClass().includes('active')">
-          <span class="bold-yellow">L</span><span class="bold-cyan">oot</span>
-        </div>
-        <div class="slot-label" v-else>
-          <span class="white">L</span><span class="bold-black">oot</span>
-        </div>
-        <img v-if="isGamepadConnected()" src="@/assets/icons/xbox/b.png" class="icon" />
+      <div class="slot-label" v-else>
+        <span class="white">F</span><span class="bold-black">lee</span>
       </div>
+      <img v-if="isGamepadConnected()" src="@/assets/icons/xbox/b.png" class="icon"/>
+    </div>
 
-      <div v-for="slot in slots()" :key="slot.slot" :class="getSlotClass(slot)" @click="runQuickSlot(slot)">
-        <NProgress v-if="getSkill(slot) && getSkill(slot).timeLeft" type="line" status="success" :percentage="100 - getSkill(slot).timeLeft / getSkill(slot).cooldownTime * 100" :show-indicator="false" />
-        <div class="slot-label">{{ slot.label }}</div>
-        <div class="slot-number">{{ slot.slot }}</div>
+    <div :class="getBattleButtonClass()" v-if="!state.gameState.battle.active" @click="conditionalCmd(isBattleButtonActive, 'battle')">
+      <div class="slot-label" v-if="isBattleButtonActive()">
+        <span class="bold-yellow">B</span><span class="bold-red">attle</span>
       </div>
+      <div class="slot-label" v-else>
+        <span class="white">B</span><span class="bold-black">attle</span>
+      </div>
+      <img v-if="isGamepadConnected()" src="@/assets/icons/xbox/x.png" class="icon"/>
+    </div>
 
+    <div :class="getHarvestButtonClass()" v-if="!state.gameState.battle.active" @click="conditionalCmd(isHarvestButtonActive, 'harvest')">
+      <div class="slot-label" v-if="isHarvestButtonActive()">
+        <span class="bold-yellow">H</span><span class="yellow">arvest</span>
+      </div>
+      <div class="slot-label" v-else>
+        <span class="white">H</span><span class="bold-black">arvest</span>
+      </div>
+      <img v-if="isGamepadConnected()" src="@/assets/icons/xbox/y.png" class="icon"/>
+    </div>
+
+    <div :class="getLootButtonClass()" v-if="!state.gameState.battle.active" @click="conditionalCmd(isLootButtonActive, 'loot')">
+      <div class="slot-label" v-if="isLootButtonActive()">
+        <span class="bold-yellow">L</span><span class="bold-cyan">oot</span>
+      </div>
+      <div class="slot-label" v-else>
+        <span class="white">L</span><span class="bold-black">oot</span>
+      </div>
+      <img v-if="isGamepadConnected()" src="@/assets/icons/xbox/b.png" class="icon"/>
+    </div>
+
+    <div v-for="slot in slots()" :key="slot.slot" :class="getSlotClass(slot)" @click="runQuickSlot(slot)">
+      <NProgress v-if="getSkill(slot) && getSkill(slot).timeLeft" type="line" status="success"
+                 :percentage="100 - getSkill(slot).timeLeft / getSkill(slot).cooldownTime * 100"
+                 :show-indicator="false"/>
+      <div class="slot-label">{{ slot.label }}</div>
+      <div class="slot-number">{{ slot.slot }}</div>
     </div>
   </div>
 </template>
@@ -84,84 +82,80 @@ const { cmd } = useWebSocket()
 const { isGamepadConnected } = useHelpers()
 
 const props = defineProps({
-  layoutMode: String
+  layoutMode: String,
 })
 
 const { layoutMode } = toRefs(props)
 
 let actionTimeout = null
 
+function conditionalCmd(condition, cmdString) {
+  if (condition()) cmd(cmdString);
+}
+function isAttackButtonActive() {
+  return state.gameState.battle.active && state.gameState.battle.myTurn;
+}
 function getAttackButtonClass () {
   let classes = ['quick-slot', 'attack']
-  if (state.gameState.battle.active && state.gameState.battle.myTurn) {
-    classes.push('active')
-    classes.push('selectable')
-  }
+  if (isAttackButtonActive()) classes.push('active')
   return classes.join(' ')
 }
 
+function isDefendButtonActive() {
+  return state.gameState.battle.active && state.gameState.battle.myTurn;
+}
 function getDefendButtonClass () {
   let classes = ['quick-slot', 'defend']
-  if (state.gameState.battle.active && state.gameState.battle.myTurn) {
-    classes.push('active')
-    classes.push('selectable')
-  }
+  if (isDefendButtonActive()) classes.push('active')
   return classes.join(' ')
 }
 
+function isFleeButtonActive() {
+  return state.gameState.battle.active && state.gameState.battle.myTurn;
+}
 function getFleeButtonClass () {
   let classes = ['quick-slot', 'flee']
-  if (state.gameState.battle.active && state.gameState.battle.myTurn) {
-    classes.push('active')
-    classes.push('selectable')
-  }
+  if (isFleeButtonActive()) classes.push('active')
   return classes.join(' ')
 }
 
+function isBattleButtonActive () {
+  return state.gameState.player.canBattle;
+}
 function getBattleButtonClass () {
   let classes = ['quick-slot', 'battle']
-  if (state.gameState.player.canBattle) {
-    classes.push('active')
-    classes.push('selectable')
-  }
+  if (isBattleButtonActive()) classes.push('active')
   return classes.join(' ')
 }
 
+function isHarvestButtonActive() {
+  return state.gameState.player.canHarvest;
+}
 function getHarvestButtonClass () {
   let classes = ['quick-slot', 'harvest']
-  if (state.gameState.player.canHarvest) {
-    classes.push('active')
-    classes.push('selectable')
-  }
+  if (isHarvestButtonActive()) classes.push('active')
   return classes.join(' ')
 }
 
+function isLootButtonActive() {
+  return state.gameState.player.canLoot;
+}
 function getLootButtonClass () {
   let classes = ['quick-slot', 'loot']
-  if (state.gameState.player.canLoot) {
-    classes.push('active')
-    classes.push('selectable')
-  }
+  if (isLootButtonActive()) classes.push('active')
   return classes.join(' ')
-}
-
-function showCombatActions () {
-  return state.gameState.battle.active && 
-    state.gameState.battle.myTurn && 
-    !state.options.showMobileMenu
 }
 
 function slots () {
   let slots = state.gameState.slots || []
-  let isNumberSlot = s => s.slot >= '1' && s.slot <= '9';
+  let isNumberSlot = s => s.slot >= '1' && s.slot <= '9'
   let numberSlots = slots.filter(isNumberSlot)
   numberSlots.sort((a, b) => a.slot.charCodeAt(0) > b.slot.charCodeAt(0) ? 1 : -1)
 
-  let nonNumberSlotsMap = new Map(slots
-      .filter(s => !isNumberSlot(s))
-      .map((s) => [s.slot, s]))
+  let nonNumberSlotsMap = new Map(slots.filter(s => !isNumberSlot(s)).map((s) => [s.slot, s]))
 
-  let addNonNumberSlot = slotChar => nonNumberSlotsMap.has(slotChar) && numberSlots.push(nonNumberSlotsMap.get(slotChar))
+  let addNonNumberSlot = slotChar => nonNumberSlotsMap.has(slotChar) &&
+      numberSlots.push(nonNumberSlotsMap.get(slotChar))
   addNonNumberSlot('0')
   addNonNumberSlot('-')
   addNonNumberSlot('=')
@@ -169,7 +163,7 @@ function slots () {
 }
 
 function runQuickSlot (slot) {
-  if (actionTimeout) {
+  if (actionTimeout || !isActive(slot)) {
     return
   }
   cmd(slot.slot)
@@ -189,26 +183,31 @@ function getMobileLayoutClass () {
   return ''
 }
 
-function getSlotClass (slot) {
+function isActive (slot) {
   let skill = getSkill(slot)
-  let classes = ['quick-slot', 'selectable']
-  if (layoutMode.value === 'mobile') {
-    classes.push('mobile-layout-mode')
+
+  if (!skill) return true;
+
+  if (skill.timeLeft) {
+    return false
+  }
+  else if (!skill.type.includes('combat') && state.gameState.battle.active) {
+    return false;
+  }
+  else if (!skill.type.includes('overworld') && (!state.gameState.battle.active || !state.gameState.battle.myTurn)) {
+    return false;
   }
 
-  if (skill) {
-    if (skill.timeLeft) {
-      return classes.join(' ')
-    }
-    if (!skill.type.includes('combat') && state.gameState.battle.active) {
-      return classes.join(' ')
-    }
-    if (!skill.type.includes('overworld') && (!state.gameState.battle.active || !state.gameState.battle.myTurn)) {
-      return classes.join(' ')
-    }
+  return true;
+}
+
+function getSlotClass (slot) {
+  let classes = ['quick-slot']
+
+  if (isActive(slot)) {
+    classes.push('active')
   }
 
-  classes.push('active')
   return classes.join(' ')
 }
 
@@ -219,197 +218,186 @@ function getSlotClass (slot) {
 .quick-container {
   display: flex;
   flex-direction: row;
-  margin-left: 8px;
-  justify-content: space-between;
+  margin-left: 9px;
   min-height: 56px;
   background-color: rgb(16, 18, 22);
-  
+  margin-right: 8px;
+  overflow-x: scroll;
+  padding: 5px 0;
+  user-select: none;
+  justify-content: left;
+  gap: 5px;
+
   &.mobile-layout-mode {
     overflow-x: initial;
+    margin-top: 10px;
+    margin-left: 11px;
+    margin-right: 11px;
+    background-color: transparent;
+    display: flex;
+    padding: 0;
     flex-wrap: wrap;
-    justify-content: space-between;
-    margin-left: 5px;
-    margin-right: 5px;
+    justify-content: left;
+  }
+}
+
+.quick-slot {
+  background-color: #222;
+  border: 1px solid #222;
+  display: flex;
+  position: relative;
+  padding: 2px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  transition: all 0.3s;
+  color: #767676;
+  border-radius: 4px;
+  height: 45px;
+
+  &:last-child {
+    margin-right: 0;
   }
 
-  .quick-actions {
-    margin-left: 1px;
-    margin-right: 8px;
-    overflow-x: scroll;
-    padding: 5px 0;
-    &.mobile-layout-mode {
-      margin-left: 1px;
-      margin-right: 8px;
-      overflow-x: initial;
-      flex-wrap: wrap;
-      justify-content: space-between;
-      margin-right: 0;
+  &.selected {
+    border: 1px solid #f8ff25;
+    box-shadow: 0 0 5px #f8ff25;
+    color: #f8ff25;
+  }
+
+  &.active {
+    color: #fff;
+    background-color: #111511;
+    border: 1px solid #16c60c;
+    cursor: pointer;
+
+    &.selected {
+      border: 1px solid #f8ff25;
+    }
+
+    @media (hover: hover) {
+      &:hover {
+        color: #f9f1a5;
+        background-color: darken(#16c60c, 33%);
+      }
+    }
+
+    .slot-number {
+      color: #ffff88;
+      background-color: lighten(#112511, 10%);
     }
   }
 
-  .quick-slots {
-    margin-right: 8px;
-  }
+  &.battle, &.attack {
+    background-color: #111;
+    border: 1px solid #808080;
+    justify-content: center;
 
-  .quick-slots, .quick-actions {
-    user-select: none;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    gap: 0 5px;
-    .quick-slot {
-      background-color: #222;
-      border: 1px solid #222;
-      display: flex;
-      position: relative;
-      padding: 2px;
-      flex-direction: column;
-      align-items: center;
-      justify-content: flex-start;
-      transition: all 0.3s;
-      color: #767676;
-      border-radius: 4px;
-      cursor: pointer;
-      height: 45px;
+    &.active {
+      background-color: #151111;
+      border: 1px solid #e88080;
 
-      &.mobile-layout-mode {
-        margin-right: 0;
-        margin-top: 5px;
-      }
-
-      &:last-child {
-        margin-right: 0;
-      }
       &.selected {
         border: 1px solid #f8ff25;
-        box-shadow: 0 0 5px #f8ff25;
-        color: #f8ff25;
       }
 
-      &.active {
-        color: #fff;
-        background-color: #111511;
-        border: 1px solid #16c60c;
-        &.selected {
-          border: 1px solid #f8ff25;
-        }
-        @media (hover: hover) {
-          &:hover {
-            cursor: pointer;
-            color: #f9f1a5;
-            background-color: darken(#16c60c, 33%);
-          }
-        }
-        .slot-number {
-          color: #ffff88;
-          background-color: lighten(#112511, 10%);
-        }
-      }
-
-      &.battle, &.attack {
-        background-color: #111;
-        border: 1px solid #808080;
-        justify-content: center;
-        &.active {
-          background-color: #151111;
-          border: 1px solid #e88080;
-          &.selected {
-            border: 1px solid #f8ff25;
-          }
-          &:hover {
-            background-color: darken(#e88080, 60%);
-          }
-        }
-
-        .slot-label {
-          font-size: 16px;
-          line-height: 16px;
-          text-align: center;
-        }
-      }
-
-      &.harvest, &.flee {
-        background-color: #111;
-        border: 1px solid #808080;
-        justify-content: center;
-        &.active {
-          background-color: #151511;
-          border: 1px solid #c6c60c;
-          &.selected {
-            border: 1px solid #f8ff25;
-          }
-          &:hover {
-            background-color: darken(#c6c60c, 33%);
-          }
-        }
-
-        .slot-label {
-          font-size: 16px;
-          line-height: 16px;
-          text-align: center;
-        }
-      }
-
-      &.loot, &.defend {
-        background-color: #111;
-        border: 1px solid #808080;
-        justify-content: center;
-
-        &.active {
-          background-color: #111515;
-          border: 1px solid #0cc6c6;
-          &.selected {
-            border: 1px solid #f8ff25;
-          }
-          &:hover {
-            background-color: darken(#0cc6c6, 33%);
-          }
-        }
-
-        .slot-label {
-          font-size: 16px;
-          line-height: 16px;
-          text-align: center;
-        }
-      }
-
-      .icon {
-        width: 20px;
-        height: 20px;
-        position: absolute;
-        bottom: 0;
-        right: 0;
-      }
-
-      .slot-number {
-        padding: 2px 4px;
-        border-bottom-right-radius: 4px;
-        border-top-left-radius: 4px;
-        position: absolute;
-        bottom: 0;
-        right: 0;
-        height: 12px;
-        font-size: 14px;
-        line-height: 12px;
-      }
-
-      .slot-label {
-        font-size: 11px;
-        width: 70px;
-        padding: 0 2px;
-        word-wrap: break-word;
-        line-height: 11px;
-        text-align: left;
-        overflow: hidden;
-      }
-
-      .n-progress {
-        --n-rail-height: 2px !important;
-        position: absolute;
-        top: 0px;
-        z-index: 5;
+      &:hover {
+        background-color: darken(#e88080, 60%);
       }
     }
+
+    .slot-label {
+      font-size: 16px;
+      line-height: 16px;
+      text-align: center;
+    }
+  }
+
+  &.harvest, &.flee {
+    background-color: #111;
+    border: 1px solid #808080;
+    justify-content: center;
+
+    &.active {
+      background-color: #151511;
+      border: 1px solid #c6c60c;
+
+      &.selected {
+        border: 1px solid #f8ff25;
+      }
+
+      &:hover {
+        background-color: darken(#c6c60c, 33%);
+      }
+    }
+
+    .slot-label {
+      font-size: 16px;
+      line-height: 16px;
+      text-align: center;
+    }
+  }
+
+  &.loot, &.defend {
+    background-color: #111;
+    border: 1px solid #808080;
+    justify-content: center;
+
+    &.active {
+      background-color: #111515;
+      border: 1px solid #0cc6c6;
+
+      &.selected {
+        border: 1px solid #f8ff25;
+      }
+
+      &:hover {
+        background-color: darken(#0cc6c6, 33%);
+      }
+    }
+
+    .slot-label {
+      font-size: 16px;
+      line-height: 16px;
+      text-align: center;
+    }
+  }
+
+  .icon {
+    width: 20px;
+    height: 20px;
+    position: absolute;
+    bottom: 0;
+    right: 0;
+  }
+
+  .slot-number {
+    padding: 2px 4px;
+    border-bottom-right-radius: 4px;
+    border-top-left-radius: 4px;
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    height: 12px;
+    font-size: 14px;
+    line-height: 12px;
+  }
+
+  .slot-label {
+    font-size: 11px;
+    width: 70px;
+    padding: 0 2px;
+    word-wrap: break-word;
+    line-height: 11px;
+    text-align: left;
+    overflow: hidden;
+  }
+
+  .n-progress {
+    --n-rail-height: 2px !important;
+    position: absolute;
+    top: 0px;
+    z-index: 5;
   }
 }
 </style>


### PR DESCRIPTION
* more consistent spacing in mobile menu
* order buttons to left
* removed superfluous container, styling rules, style nesting and classes
* buttons will not have pointer cursor/respond to clicks if not active
* mild code cleanup

| Before | After |
| ------------- | ------------- |
| ![image](https://github.com/dinchak/procrealms-web-client/assets/1077140/c9fc2182-b4a4-489c-9865-f0a325e7ba1f) | ![2024-05-24_15-37-22__chrome](https://github.com/dinchak/procrealms-web-client/assets/1077140/cbe09a44-40de-4ee2-92f2-971de73ef373) |

No visual differences made to HUD quickslots