### PR TITLE
feat: rudimentary music autoplay

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,6 +18,8 @@ import { useWebSocket } from '@/composables/web_socket'
 import { useLocalStorageHandler } from './composables/local_storage_handler'
 import { CACHE_DELETE_TIME, CACHE_DELETE_INTERVAL } from '@/static/constants'
 
+import { stopPlaying } from '@/static/sound'
+
 import InputHandler from '@/components/InputHandler.vue'
 import SplashScreen from '@/components/SplashScreen.vue'
 import LoginModal from '@/components/modals/LoginModal.vue'
@@ -52,6 +54,7 @@ function onClose () {
   state.disconnected = true
   state.connected = false
   setTimeout(() => doConnect(), 1000)
+  stopPlaying()
 }
 
 function clearCache(object) {

--- a/src/components/common/MusicPlayer.vue
+++ b/src/components/common/MusicPlayer.vue
@@ -47,7 +47,7 @@ import SkipNextOutlined from '@vicons/material/SkipNextOutlined'
 import VolumeDownOutlined from '@vicons/material/VolumeDownOutlined'
 
 import { state } from '@/static/state'
-import { stopPlaying, playRandomTrack } from '@/static/sound'
+import { stopPlaying, playRandomTrack, startPlaying } from '@/static/sound'
 
 let analyzerData = null
 let stopAnalysis = false
@@ -61,15 +61,11 @@ const analyzer = ref(null)
 const trackName = ref(null)
 
 async function play () {
-  const { audioContext } = state.music
-
-  if (audioContext.state === 'suspended') {
-    await audioContext.resume()
-    state.music.playing = true
-  }
-
   if (!state.music.currentTrack) {
     await playRandomTrack()
+  }
+  else {
+    startPlaying(state.music.currentTrack)
   }
 }
 

--- a/src/components/game-modal/OptionsPane.vue
+++ b/src/components/game-modal/OptionsPane.vue
@@ -68,6 +68,13 @@
           </div>
         </NGi>
 
+        <NGi>
+          <div class="option">
+            <label for="option-autoplay-music">Autoplay Music</label>
+            <NSwitch id="option-autoplay-music" v-model:value="state.options.autoplayMusic" aria-label="Autoplay Music" class="selectable"></NSwitch>
+          </div>
+        </NGi>
+
       </NGrid>
     </div>
 

--- a/src/components/mobile-menu/OptionsMenu.vue
+++ b/src/components/mobile-menu/OptionsMenu.vue
@@ -45,6 +45,11 @@
       <n-switch id="option-text-input-always-focused" v-model:value="state.options.textInputAlwaysFocused" aria-label="Text Input Always Focused"></n-switch>
     </div>
 
+    <div class="option">
+      <label for="option-autoplay-music">Autoplay Music</label>
+      <n-switch id="option-autoplay-music" v-model:value="state.options.autoplayMusic" aria-label="Auto Play Music"></n-switch>
+    </div>
+
     <h3 class="pad-top">Font Settings</h3>
 
     <n-select

--- a/src/static/sound.js
+++ b/src/static/sound.js
@@ -17,7 +17,7 @@ export async function playRandomTrack () {
 export function stopPlaying (pause) {
   const { musicSource, audioContext } = state.music
 
-  audioContext.suspend()
+  audioContext?.suspend()
 
   if (!pause && musicSource) {
     musicSource.stop()
@@ -54,11 +54,7 @@ export async function startPlaying (track) {
 
     musicSource.addEventListener('ended', async (ev) => {
       if (track.name !== state.music.currentTrack.name) return;
-      if (playingNewTrack) return;
-      if (trackLoading) return;
       if (state.music.musicSource !== ev.target) return;
-
-      if (audioContext.state === 'suspended') return;
       console.debug("randum")
       await playRandomTrack();
     })

--- a/src/static/sound.js
+++ b/src/static/sound.js
@@ -4,8 +4,10 @@ import { MUSIC_TRACKS } from '@/static/constants'
 let trackLoading = false
 
 export async function playTrackByName(name) {
+  const { currentTrack } = state.music;
+  if (currentTrack.name === name) return;
   let track = MUSIC_TRACKS.find(t => t.name === name)
-  if (!track || state.music.currentTrack === track) return;
+  if (!track) return;
   await startPlaying(track)
 }
 

--- a/src/static/sound.js
+++ b/src/static/sound.js
@@ -3,6 +3,13 @@ import { MUSIC_TRACKS } from '@/static/constants'
 
 let trackLoading = false
 
+export async function playTrack(name) {
+  let track = MUSIC_TRACKS.find(t => t.name === name)
+  if (!track || state.music.currentTrack === track) return;
+  state.music.currentTrack = track
+  await startPlaying(track)
+}
+
 export async function playRandomTrack () {
   let track = MUSIC_TRACKS[Math.random() * MUSIC_TRACKS.length | 0]
   state.music.currentTrack = track

--- a/src/static/state.js
+++ b/src/static/state.js
@@ -110,7 +110,7 @@ export const state = reactive({
     musicSource: null,
     audioAnalyzer: null,
     gainNode: null,
-    currentTrack: false,
+    currentTrack: null,
     playing: false
   }
 })

--- a/src/static/state.js
+++ b/src/static/state.js
@@ -220,6 +220,9 @@ function resetOptions () {
     // terminal size
     terminalWidth: DEFAULT_TERMINAL_SIZE.width,
     terminalHeight: DEFAULT_TERMINAL_SIZE.height,
+
+    // music
+    autoplayMusic: false,
   }
 }
 

--- a/src/static/state.js
+++ b/src/static/state.js
@@ -4,7 +4,8 @@ import { EventEmitter } from 'events'
 import { loadSettingsByNameAndType } from '@/static/triggers'
 
 import { useLocalStorageHandler } from '@/composables/local_storage_handler'
-import { DEFAULT_TERMINAL_SIZE } from '@/static/constants.js'
+import { DEFAULT_TERMINAL_SIZE } from '@/static/constants'
+import { playRandomTrack } from '@/static/sound'
 
 const { addToken } = useLocalStorageHandler()
 
@@ -237,6 +238,7 @@ export function authenticationSuccess ({ name, token }) {
   state.modals.newPlayerModal = false
   loadSettingsByNameAndType(state.triggers, name, 'triggers')
   loadSettingsByNameAndType(state.variables, name, 'variables')
+  if (state.options.autoplayMusic) playRandomTrack()
 }
 
 function addSuggestedCommand (command) {

--- a/src/static/web_socket_handlers.js
+++ b/src/static/web_socket_handlers.js
@@ -3,7 +3,7 @@ import jiff from 'jiff'
 import { CHANNEL_COLORS } from '@/static/constants'
 import { addLine, state, setMode } from '@/static/state'
 import { processTriggers } from '@/static/triggers'
-
+import { playTrack } from '@/static/sound'
 import { useHelpers } from '@/composables/helpers'
 
 const { ansiToHtml, strToLines } = useHelpers()
@@ -176,5 +176,30 @@ const webSocketHandlers = {
   
   'help.search': ({ matches }) => {
     state.help.searchResults = matches
+  },
+
+  'client.media.play': ({ name, volume }) => {
+    // Intercept known OST tracks
+    if (!state.options.autoplayMusic) return;
+    switch (name) {
+      case "music/ost/my-portal.mp3":
+        playTrack('My Portal');
+        break;
+      case "music/ost/the-endless-sands.mp3":
+        playTrack('The Endless Sands');
+        break;
+      case "music/ost/the-hidden-grove.mp3":
+        playTrack('The Hidden Grove');
+        break;
+      case "music/ost/the-nexus.mp3":
+        playTrack('The Nexus');
+        break;
+      case "music/ost/the-plains.mp3":
+        playTrack('The Great Plains');
+        break;
+      case "music/ost/the-shrine.mp3":
+        playTrack('The Shrine');
+        break;
+    }
   }
 }

--- a/src/static/web_socket_handlers.js
+++ b/src/static/web_socket_handlers.js
@@ -180,7 +180,7 @@ const webSocketHandlers = {
 
   'client.media.play': ({ name, volume }) => {
     // Intercept known OST tracks
-    if (!state.options.autoplayMusic) return;
+    if (!state.options.autoplayMusic || state.music.audioContext?.state === 'suspended') return;
     switch (name) {
       case "music/ost/my-portal.mp3":
         playTrackByName('My Portal');

--- a/src/static/web_socket_handlers.js
+++ b/src/static/web_socket_handlers.js
@@ -3,7 +3,7 @@ import jiff from 'jiff'
 import { CHANNEL_COLORS } from '@/static/constants'
 import { addLine, state, setMode } from '@/static/state'
 import { processTriggers } from '@/static/triggers'
-import { playTrack } from '@/static/sound'
+import { playTrackByName } from '@/static/sound'
 import { useHelpers } from '@/composables/helpers'
 
 const { ansiToHtml, strToLines } = useHelpers()
@@ -183,22 +183,22 @@ const webSocketHandlers = {
     if (!state.options.autoplayMusic) return;
     switch (name) {
       case "music/ost/my-portal.mp3":
-        playTrack('My Portal');
+        playTrackByName('My Portal');
         break;
       case "music/ost/the-endless-sands.mp3":
-        playTrack('The Endless Sands');
+        playTrackByName('The Endless Sands');
         break;
       case "music/ost/the-hidden-grove.mp3":
-        playTrack('The Hidden Grove');
+        playTrackByName('The Hidden Grove');
         break;
       case "music/ost/the-nexus.mp3":
-        playTrack('The Nexus');
+        playTrackByName('The Nexus');
         break;
       case "music/ost/the-plains.mp3":
-        playTrack('The Great Plains');
+        playTrackByName('The Great Plains');
         break;
       case "music/ost/the-shrine.mp3":
-        playTrack('The Shrine');
+        playTrackByName('The Shrine');
         break;
     }
   }

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -39,6 +39,7 @@
 <script setup>
 import { onMounted, onBeforeUnmount, watch } from 'vue'
 import { NLayout } from 'naive-ui'
+import { playRandomTrack } from '@/static/sound'
 
 import ButtonControls from '@/components/main-area/ButtonControls.vue'
 import GameModal from '@/components/modals/GameModal.vue'
@@ -146,6 +147,8 @@ function startAudioContext (ev) {
   state.music.gainNode = state.music.audioContext.createGain()
   state.music.gainNode.connect(state.music.audioAnalyzer)
   state.music.gainNode.gain.value = state.options.volume / 100.0  
+
+  if (state.options.autoplayMusic) playRandomTrack()
 
   for (let eventName of USER_GESTURE_EVENTS) {
     window.removeEventListener(eventName, startAudioContext)

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -39,7 +39,6 @@
 <script setup>
 import { onMounted, onBeforeUnmount, watch } from 'vue'
 import { NLayout } from 'naive-ui'
-import { playRandomTrack } from '@/static/sound'
 
 import ButtonControls from '@/components/main-area/ButtonControls.vue'
 import GameModal from '@/components/modals/GameModal.vue'
@@ -146,9 +145,7 @@ function startAudioContext (ev) {
 
   state.music.gainNode = state.music.audioContext.createGain()
   state.music.gainNode.connect(state.music.audioAnalyzer)
-  state.music.gainNode.gain.value = state.options.volume / 100.0  
-
-  if (state.options.autoplayMusic) playRandomTrack()
+  state.music.gainNode.gain.value = state.options.volume / 100.0
 
   for (let eventName of USER_GESTURE_EVENTS) {
     window.removeEventListener(eventName, startAudioContext)


### PR DESCRIPTION
Configurable via new setting (Default: off)

* Starts playing a random track when you log in
* Responds to `client.media.play` trying to play an OST from the sound repository (translates it to the music tracks in the player list)
* Some code changes to allow pausing and resuming tracks while maintaining playing the next random track on track end