### PR TITLE
chore: nicer debug format

### DIFF
--- a/src/composables/web_socket.js
+++ b/src/composables/web_socket.js
@@ -23,7 +23,7 @@ export function useWebSocket () {
           state.cache.commandCache[reqId] = msg
         }
         if (import.meta.env.MODE == 'development') {
-          console.log(`%c<%c ${cmd} %c${msg ? JSON.stringify(msg) : ''} ${reqId ? ` (reqId=${reqId})` : ''}`, 'background-color: #226622; color: #fff', 'color: #33ff33', 'color: #ccffcc')
+          console.log(`%c<%c ${cmd}${reqId ? ` (reqId=${reqId})` : ''}`, 'background-color: #226622; color: #fff', 'color: #33ff33', msg)
         }
 
         reqId ? onWebSocketEvent(cmd, msg, reqId) : onWebSocketEvent(cmd, msg)
@@ -38,7 +38,7 @@ export function useWebSocket () {
     let out = { cmd, msg }
 
     if (import.meta.env.MODE == 'development') {
-      console.log(`%c>%c ${cmd} %c${msg ? JSON.stringify(msg) : ''}`, 'background-color: #662222; color: #fff', 'color: #ff3333', 'color: #ffcccc')
+      console.log(`%c>%c ${cmd}`, 'background-color: #662222; color: #fff', 'color: #ff3333', msg)
     }
 
     state.websocketConnection.send(JSON.stringify(out))


### PR DESCRIPTION
Personally I prefer it like this, since I can open/close and search the JS objects like this instead of trying to read the big block of text. It seems to keep the console tidier.

![2024-05-25_22-34-16__chrome](https://github.com/dinchak/procrealms-web-client/assets/1077140/f8cc4671-aa82-42c5-a87b-17772978df46)


If you disagree, that's fine! Just close and ignore the PR.