### PR TITLE
reuse help tabs if an entry is already open

### DIFF
--- a/src/components/modals/HelpModal.vue
+++ b/src/components/modals/HelpModal.vue
@@ -336,7 +336,15 @@ function handleCloseTab (name) {
   if (name == 'topics') {
     return
   }
-  state.help.openEntries = state.help.openEntries.filter(e => e.entry != name)
+  const currentIndex = state.help.openEntries.findIndex(e => e.entry == name)
+  state.help.openEntries = state.help.openEntries.filter(e => e.entry !== name)
+  panes.value = panes.value.filter(p => p !== name)
+
+  if (currentIndex && state.help.openEntries.length) {
+    state.gamepadHelpTab = state.help.openEntries[currentIndex - 1].entry
+  } else {
+    state.gamepadHelpTab = 'topics'
+  }
 }
 
 function getRecentOutput () {
@@ -452,8 +460,12 @@ onMounted(() => {
   )
 
   watchers.push(
-    watch(() => state.help.openEntries.length, () => {
-      currentPane.value = state.help.openEntries[state.help.openEntries.length - 1]?.entry || "topics"
+    watch(() => state.gamepadHelpTab, () => {
+      const tab = state.gamepadHelpTab
+      currentPane.value = tab || "topics"
+      if (!panes.value.includes(tab)) {
+        panes.value.push(tab);
+      }
     }
   ))
 })

--- a/src/static/web_socket_handlers.js
+++ b/src/static/web_socket_handlers.js
@@ -164,8 +164,10 @@ const webSocketHandlers = {
   
   'help.entry': ({ entry, content }) => {
     let helpFile = { entry, content }
-    state.help.contents.push(helpFile)
-    state.help.openEntries.push(helpFile)
+    if (!state.help.openEntries.some(e => e.entry == entry)) {
+      state.help.contents.push(helpFile)
+      state.help.openEntries.push(helpFile)
+    }
     state.gamepadHelpTab = entry
     if (!state.modals.helpModal) {
       console.log(`opening help modal`)


### PR DESCRIPTION
This also fixes a bug with the gamepad navigation. It was using the `panes` variable to do navigation but `panes` was never maintained when opening/closing new files