### PR TITLE
Make inventory items expand only the items and not other columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "vite build",
     "buildqa": "vite build --mode qa",
     "preview": "vite preview"

--- a/src/components/game-modal/InventoryPane.vue
+++ b/src/components/game-modal/InventoryPane.vue
@@ -26,10 +26,10 @@
     </NGrid>
 
     <div class="item-table">
-      <div class="inventory" v-for="(e, i) in 3" :key="i">
+      <div class="inventory" v-for="(e, i) in columns" :key="i">
         <div v-if="getItems().length == 0">You don't have anything in your inventory.</div>
         <div v-for="(item, index) in getItems()" :key="item.iid">
-          <div :class=itemClass(item.iid) v-if="index % 3 === i">
+          <div :class=itemClass(item.iid) v-if="index % columns === i">
             <div class="name selectable" v-html-safe="ansiToHtml(item.fullName)" :class="getItemNameClass(item)" @click="selectItem(item)"></div>
               <ItemDetails :item="item" :actions="getActions(item)" v-if="selectedIid == item.iid"></ItemDetails>
           </div>
@@ -60,6 +60,7 @@ const { miniOutputEnabled } = toRefs(props)
 const items = ref([])
 const selectedIid = ref({})
 const search = ref('')
+const columns = ref(1)
 
 function getItems () {
   if (search.value) {
@@ -136,8 +137,21 @@ function itemClass(itemIid) {
   return selectedIid.value === itemIid ? 'item border selected-item' : 'item'
 }
 
+function onWidthChange() {
+  if (window.innerWidth < 600) {
+    columns.value = 1
+  } else if (window.innerWidth < 800) {
+    columns.value = 2
+  } else {
+    columns.value = 3
+  }
+}
+
 let watchers = []
 onMounted(async () => {
+  onWidthChange()
+  window.addEventListener('resize', onWidthChange)
+
   items.value = await fetchItems(getInventory())
   
   watchers.push(
@@ -161,6 +175,7 @@ onMounted(async () => {
 onBeforeUnmount(() => {
   watchers.forEach(w => w())
   unwatchCharmieInventory()
+  window.removeEventListener('resize', onWidthChange)
 })
 </script>
 
@@ -242,6 +257,9 @@ onBeforeUnmount(() => {
 
 @media screen and (max-width: 800px) {
   .scroll-container {
+    .inventory {
+      width: 50%;
+    }
     .inventory-summary {
       .summary {
         .money {
@@ -257,6 +275,9 @@ onBeforeUnmount(() => {
 
 @media screen and (max-width: 600px) {
   .scroll-container {
+    .inventory {
+      width: 100%;
+    }
     .inventory-summary {
       .summary {
         flex-direction: row;

--- a/src/components/game-modal/InventoryPane.vue
+++ b/src/components/game-modal/InventoryPane.vue
@@ -25,19 +25,17 @@
       </NGi>
     </NGrid>
 
-    <NGrid class="inventory" cols="1 800:2 1200:3">
-      <NGi v-if="getItems().length == 0">You don't have anything in your inventory.</NGi>
-
-      <NGi v-for="item in getItems()" :key="item.iid">
-        <div class="item">
-          <div class="name selectable" v-html-safe="ansiToHtml(item.fullName)" :class="getItemNameClass(item)" @click="selectItem(item)"></div>
-
-          <ItemDetails :item="item" :actions="getActions(item)" v-if="selectedIid == item.iid"></ItemDetails>
-
+    <div class="item-table">
+      <div class="inventory" v-for="(e, i) in 3" :key="i">
+        <div v-if="getItems().length == 0">You don't have anything in your inventory.</div>
+        <div v-for="(item, index) in getItems()" :key="item.iid">
+          <div :class=itemClass(item.iid) v-if="index % 3 === i">
+            <div class="name selectable" v-html-safe="ansiToHtml(item.fullName)" :class="getItemNameClass(item)" @click="selectItem(item)"></div>
+              <ItemDetails :item="item" :actions="getActions(item)" v-if="selectedIid == item.iid"></ItemDetails>
+          </div>
         </div>
-      </NGi>
-
-    </NGrid>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -134,6 +132,10 @@ function watchCharmieInventory () {
   })
 }
 
+function itemClass(itemIid) {
+  return selectedIid.value === itemIid ? 'item border selected-item' : 'item'
+}
+
 let watchers = []
 onMounted(async () => {
   items.value = await fetchItems(getInventory())
@@ -163,6 +165,10 @@ onBeforeUnmount(() => {
 </script>
 
 <style lang="less" scoped>
+.item-table {
+  display: flex;
+  width: 100%;
+}
 .scroll-container {
   height: calc(100vh - 75px);
   overflow-y: scroll;
@@ -208,6 +214,16 @@ onBeforeUnmount(() => {
     }
   }
   .inventory {
+    width: 33%;
+    display: flex;
+    justify-content: flex-start;
+    align-items: flex-start;
+    flex-direction: column;
+    .selected-item {
+      border-style: solid;
+      border-width: 0.2rem;
+      border-color: #121;
+    }
     .item {
       .name {
         padding: 5px 10px;


### PR DESCRIPTION
- Currently, in the inventory pane, when we click on an item it expands not only the item with the details, but the other columns with blank space, which doesn't look good or intended. This PR addresses it with using three dynamic flex columns instead of a native UI grid.
- Added a slight border to the selected item to better differentiate it.
- Adding `--host` to the `vite dev` script in order to expose the IP to the local network, which allows us to also test from a phone or tablet connected to the same network.

**Before**
![image](https://github.com/dinchak/procrealms-web-client/assets/11844042/fca289f8-140c-4855-9bce-b31a73f6d9c9)

**After**
![image](https://github.com/dinchak/procrealms-web-client/assets/11844042/a7c22587-2daa-4748-9372-0d3032ec524a)
