### PR TITLE
Fix triple display for empty inventory message

### DIFF
--- a/src/components/game-modal/InventoryPane.vue
+++ b/src/components/game-modal/InventoryPane.vue
@@ -24,10 +24,9 @@
         </div>
       </NGi>
     </NGrid>
-
+    <div v-if="getItems().length == 0">You don't have anything in your inventory.</div>
     <div class="item-table">
       <div class="inventory" v-for="(e, i) in columns" :key="i">
-        <div v-if="getItems().length == 0">You don't have anything in your inventory.</div>
         <div v-for="(item, index) in getItems()" :key="item.iid">
           <div :class=itemClass(item.iid) v-if="index % columns === i">
             <div class="name selectable" v-html-safe="ansiToHtml(item.fullName)" :class="getItemNameClass(item)" @click="selectItem(item)"></div>


### PR DESCRIPTION
Quick fix for `You don't have anything in your inventory.` message showing 3 times

**Before**
![image](https://github.com/dinchak/procrealms-web-client/assets/11844042/5c5bf126-a577-4904-b1a5-488d6052b11a)

**After**

![image](https://github.com/dinchak/procrealms-web-client/assets/11844042/f6253399-ef6f-4836-b90a-4458e96b118e)
