### PR TITLE
Changed inventory sorting 

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-VITE_WEBSOCKET_URL=ws://localhost:8001
-VITE_TITLE=Dev - Procedural Realms
+VITE_WEBSOCKET_URL=wss://play.proceduralrealms.com/ws
+VITE_TITLE=Procedural Realms

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+console.log('Happy developing ✨')

--- a/package.json
+++ b/package.json
@@ -1,35 +1,10 @@
 {
-  "name": "procedural-realms-client",
-  "version": "0.0.0",
-  "private": true,
-  "type": "module",
+  "name": "procrealms-web-client",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
   "scripts": {
-    "dev": "vite --host",
-    "build": "vite build",
-    "buildqa": "vite build --mode qa",
-    "preview": "vite preview"
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "dependencies": {
-    "ansi_up": "^6.0.2",
-    "ansi-to-span": "^0.0.1",
-    "dayjs": "^1.11.10",
-    "events": "^3.3.0",
-    "jiff": "^0.7.3",
-    "nanoid": "^5.0.9",
-    "strip-ansi": "^7.1.0",
-    "vue": "^3.4.15",
-    "vue-html-secure": "^1.0.10",
-    "vue-router": "^4.3.0"
-  },
-  "devDependencies": {
-    "@eslint/js": "^9.21.0",
-    "@vicons/material": "^0.12.0",
-    "@vitejs/plugin-vue": "^5.0.3",
-    "eslint": "^9.21.0",
-    "eslint-plugin-vue": "^9.32.0",
-    "globals": "^16.0.0",
-    "less": "^4.2.0",
-    "naive-ui": "^2.38.1",
-    "vite": "^5.4.11"
-  }
+  "private": true
 }

--- a/src/components/game-modal/InventoryPane.vue
+++ b/src/components/game-modal/InventoryPane.vue
@@ -38,14 +38,16 @@
       <div class="inventory" v-for="i in columns" :key="i">
         <div v-for="item in getColumnItems(i - 1)" :key="item.iid" class="item-row">
           <div :class="itemClass(item.iid)">
-            <div class="name selectable" v-html-safe="ansiToHtml(item.fullName)" :class="getItemNameClass(item)" @click="selectItem(item)"></div>
-            <ItemDetails :item="selectedItem" :actions="getActions(item)" :item-output-id="item.iid" v-if="selectedIid == item.iid"></ItemDetails>
+            <div class="name selectable" v-html-safe="ansiToHtml(item.fullName)" :class="getItemNameClass(item)"
+                 @click="selectItem(item)"></div>
+            <ItemDetails :item="selectedItem" :actions="getActions(item)" :item-output-id="item.iid"
+                         v-if="selectedIid == item.iid"></ItemDetails>
           </div>
         </div>
       </div>
     </div>
 
-</div>
+  </div>
 </template>
 
 <script setup>
@@ -60,7 +62,7 @@ import { state } from '@/static/state'
 import { useHelpers } from '@/composables/helpers'
 import { useWebSocket } from '@/composables/web_socket'
 
-const { ansiToHtml, copperToMoneyString, getActions } = useHelpers()
+const { ansiToHtml, copperToMoneyString, getActions, sortInventoryItems } = useHelpers()
 const { fetchItem } = useWebSocket()
 
 const props = defineProps(['miniOutputEnabled'])
@@ -178,6 +180,7 @@ function mapInventory () {
 }
 
 let charmieInventoryWatcher = null
+
 function unwatchCharmieInventory () {
   if (charmieInventoryWatcher) {
     charmieInventoryWatcher()
@@ -215,8 +218,7 @@ function onSortChange () {
 }
 
 function sortItems (its) {
-  its.sort((a, b) => { return a[state.inventorySortValue] > b[state.inventorySortValue] ? 1 : -1 })
-  return its
+  return sortInventoryItems(its, state.inventorySortValue)
 }
 
 function getColumnItems (colIndex) {
@@ -271,6 +273,7 @@ onBeforeUnmount(() => {
   display: flex;
   width: 100%;
 }
+
 .scroll-container {
   height: calc(100vh - 75px);
   overflow-y: scroll;
@@ -287,34 +290,42 @@ onBeforeUnmount(() => {
     justify-content: space-between;
     align-items: center;
     padding: 10px;
+
     .cell {
       margin: 5px 5px;
     }
+
     .summary {
       display: flex;
       flex-direction: column;
       justify-content: flex-end;
+
       .money {
         text-align: right;
       }
+
       .money-brief {
         display: none;
         text-align: right;
       }
+
       .limit {
         display: flex;
         flex-direction: row;
         justify-content: flex-end;
+
         .value {
           text-align: right;
           margin-right: 10px;
         }
+
         .label {
           text-align: left;
         }
       }
     }
   }
+
   .sorting {
     margin-bottom: 20px;
     margin-left: 5px;
@@ -335,13 +346,17 @@ onBeforeUnmount(() => {
     align-items: flex-start;
     flex-direction: column;
     flex-grow: 1;
+
     .item-row {
       width: 100%;
+
       .item {
         width: 100%;
+
         .name {
           padding: 5px 10px;
           cursor: pointer;
+
           &.selected {
             background: #121;
           }
@@ -360,11 +375,13 @@ onBeforeUnmount(() => {
     .inventory {
       width: 50%;
     }
+
     .inventory-summary {
       .summary {
         .money {
           display: none;
         }
+
         .money-brief {
           display: block;
         }
@@ -378,6 +395,7 @@ onBeforeUnmount(() => {
     .inventory {
       width: 100%;
     }
+
     .inventory-summary {
       .summary {
         flex-direction: row;

--- a/src/components/mobile-menu/collapse-items/InventoryCollapse.vue
+++ b/src/components/mobile-menu/collapse-items/InventoryCollapse.vue
@@ -3,32 +3,34 @@
     <div class="money" v-html-safe=copperToMoneyString(getMoney())></div>
 
     <div class="limits">
-      <div class="items">{{getNumItems()}}/{{getMaxNumItems()}} items</div>
-      <div class="weight">{{getWeight()}}/{{getMaxWeight()}} lbs</div>
+      <div class="items">{{ getNumItems() }}/{{ getMaxNumItems() }} items</div>
+      <div class="weight">{{ getWeight() }}/{{ getMaxWeight() }} lbs</div>
     </div>
 
     <div v-if="items.length !== 0" class="inventory-items">
       <div class="search">
-        <NInput v-model:value="searchTerm" ref="searchInput" @blur="onBlur" @focus="onFocus" placeholder="Search"></NInput>
+        <NInput v-model:value="searchTerm" ref="searchInput" @blur="onBlur" @focus="onFocus"
+                placeholder="Search"></NInput>
       </div>
 
       <div class="sorting">
         <span>Sort by </span>
         <NPopselect v-model:value="value" :options="options">
-          <span class="dropdown">{{value}}</span>
+          <span class="dropdown">{{ value }}</span>
         </NPopselect>
       </div>
 
       <div v-for="item in filteredItems" :key="item.iid">
         <InventoryRow
-          :iid="item.iid"
-          :item="item"
-          :selected="getSelected(item.iid)"
-          v-on:click="clickHandler(item.iid)"
+            :iid="item.iid"
+            :item="item"
+            :selected="getSelected(item.iid)"
+            v-on:click="clickHandler(item.iid)"
         ></InventoryRow>
 
         <div class="inline-details" v-if="selectedIid == item.iid">
-          <ItemDetails :item="selectedItem" :actions="getActions(selectedItem)" :item-output-id="item.iid"></ItemDetails>
+          <ItemDetails :item="selectedItem" :actions="getActions(selectedItem)"
+                       :item-output-id="item.iid"></ItemDetails>
         </div>
       </div>
     </div>
@@ -48,7 +50,7 @@ import { useWebSocket } from '@/composables/web_socket'
 import { useHelpers } from '@/composables/helpers'
 
 const { fetchItem } = useWebSocket()
-const { copperToMoneyString, getActions } = useHelpers()
+const { copperToMoneyString, getActions, sortInventoryItems } = useHelpers()
 
 const props = defineProps(['inventory', 'isPlayer', 'character', 'effects', 'menu'])
 
@@ -109,9 +111,7 @@ onMounted(() => {
   }))
 
   watchers.push(watch(value, () => {
-    filteredItems.value = filteredItems.value.sort((a, b) => {
-      return a[value.value] > b[value.value] ? 1 : -1
-    })
+    filteredItems.value = sortInventoryItems(filteredItems.value, value.value)
   }))
 })
 
@@ -145,15 +145,15 @@ function setItems (inventory) {
 
   const input = searchTerm.value.toLowerCase()
 
-  filteredItems.value = items.value.filter(item => {
+  filteredItems.value = sortInventoryItems(items.value.filter(item => {
     return (item.name.toLowerCase().includes(input) ||
-      item.colorName.toLowerCase().includes(input) ||
-      item.type.toLowerCase().includes(input)) ||
-      (item.subtype ? item.subtype.toLowerCase().includes(input) : false)
-  })
-    .sort((a, b) => {
-      return a[value.value] > b[value.value] ? 1 : -1
-    })
+            item.colorName.toLowerCase().includes(input) ||
+            item.type.toLowerCase().includes(input)) ||
+        (item.subtype ? item.subtype.toLowerCase().includes(input) : false)
+  }), value.value)
+  // .sort((a, b) => {
+  //   return a[value.value] > b[value.value] ? 1 : -1
+  // })
 }
 
 function clickHandler (iid) {

--- a/src/components/modals/TradeModal.vue
+++ b/src/components/modals/TradeModal.vue
@@ -1,11 +1,11 @@
 <template>
   <GameModal
-    v-model="state.modals.tradeModal"
-    title="Trade Menu"
-    modal-class="trade-modal"
-    modal-key="tradeModal"
-    @opened="onModalOpened"
-    @closed="onModalClosed"
+      v-model="state.modals.tradeModal"
+      title="Trade Menu"
+      modal-class="trade-modal"
+      modal-key="tradeModal"
+      @opened="onModalOpened"
+      @closed="onModalClosed"
   >
     <div class="trade-container">
       <div class="trade-columns">
@@ -18,7 +18,8 @@
             <div class="filters">
               <div class="sorting">
                 <span>Sort by </span>
-                <NPopselect v-model:value="shopkeeperSortValue" :options="sortOptions" @update:value="onShopkeeperSortChange">
+                <NPopselect v-model:value="shopkeeperSortValue" :options="sortOptions"
+                            @update:value="onShopkeeperSortChange">
                   <span class="dropdown">{{ shopkeeperSortValue }}</span>
                 </NPopselect>
               </div>
@@ -33,8 +34,10 @@
           <div class="shop-inventory">
             <div v-for="{ name, iid } in state.shop.items" :key="iid" class="item-row">
               <div :class=itemClass(iid)>
-                <div class="name selectable" v-html-safe="ansiToHtml(name)" :class="getItemNameClass(iid)" @click="selectItem(iid)"></div>
-                  <ItemDetails :item="selectedItem" :actions="getBuyActions(selectedItem)" :item-output-id="iid" v-if="selectedIid == iid"></ItemDetails>
+                <div class="name selectable" v-html-safe="ansiToHtml(name)" :class="getItemNameClass(iid)"
+                     @click="selectItem(iid)"></div>
+                <ItemDetails :item="selectedItem" :actions="getBuyActions(selectedItem)" :item-output-id="iid"
+                             v-if="selectedIid == iid"></ItemDetails>
               </div>
             </div>
           </div>
@@ -48,7 +51,8 @@
             <div class="filters">
               <div class="sorting">
                 <span>Sort by </span>
-                <NPopselect v-model:value="state.inventorySortValue" :options="sortOptions" @update:value="onInventorySortChange">
+                <NPopselect v-model:value="state.inventorySortValue" :options="sortOptions"
+                            @update:value="onInventorySortChange">
                   <span class="dropdown">{{ state.inventorySortValue }}</span>
                 </NPopselect>
               </div>
@@ -58,8 +62,10 @@
           <div class="player-inventory">
             <div v-for="item in playerItems" :key="item.iid" class="item-row">
               <div :class=itemClass(item.iid)>
-                <div class="name selectable" v-html-safe="ansiToHtml(item.fullName)" :class="getItemNameClass(item)" @click="selectItem(item.iid)"></div>
-                  <ItemDetails :item="item" :actions="getSellActions(item)" :item-output-id="item.iid" v-if="selectedIid == item.iid"></ItemDetails>
+                <div class="name selectable" v-html-safe="ansiToHtml(item.fullName)" :class="getItemNameClass(item)"
+                     @click="selectItem(item.iid)"></div>
+                <ItemDetails :item="item" :actions="getSellActions(item)" :item-output-id="item.iid"
+                             v-if="selectedIid == item.iid"></ItemDetails>
               </div>
             </div>
           </div>
@@ -79,10 +85,12 @@ import GameModal from '@/components/modals/GameModal.vue'
 import ItemDetails from '@/components/game-modal/ItemDetails.vue'
 
 import { useWebSocket } from '@/composables/web_socket'
+
 const { runCommand, fetchItems, fetchEntity, fetchItem } = useWebSocket()
 
 import { useHelpers } from '@/composables/helpers'
-const { ansiToHtml, copperToMoneyString, runItemAction, getActions } = useHelpers()
+
+const { ansiToHtml, copperToMoneyString, runItemAction, getActions, sortInventoryItems } = useHelpers()
 
 const shopItems = ref([])
 const playerItems = ref([])
@@ -274,11 +282,7 @@ function onInventorySortChange () {
 }
 
 function sortPlayerItems (items) {
-  items.sort((a, b) => {
-    return a[state.inventorySortValue] > b[state.inventorySortValue] ? 1 : -1
-  })
-
-  return items
+  return sortInventoryItems(items, state.inventorySortValue)
 }
 
 function onShopkeeperSortChange () {
@@ -286,11 +290,8 @@ function onShopkeeperSortChange () {
 }
 
 function sortShopkeeperItems (items) {
-  items.sort((a, b) => {
-    return a[shopkeeperSortValue.value] > b[shopkeeperSortValue.value] ? 1 : -1
-  })
-
-  return items
+  // TODO This currently doesn't work because it's being called after the list is displayed.
+  return sortInventoryItems(items, shopkeeperSortValue.value)
 }
 
 </script>
@@ -315,6 +316,7 @@ function sortShopkeeperItems (items) {
         margin: 2px 0 5px 0;
         padding-bottom: 5px;
         border-bottom: 1px solid #333;
+
         .filters {
           display: flex;
           flex-direction: row;
@@ -350,11 +352,14 @@ function sortShopkeeperItems (items) {
 
         .item-row {
           width: 100%;
+
           .item {
             width: 100%;
+
             .name {
               padding: 5px 10px;
               cursor: pointer;
+
               &.selected {
                 background: #121;
               }

--- a/src/static/state.js
+++ b/src/static/state.js
@@ -51,7 +51,7 @@ export const state = reactive({
   mercEid: -1,
 
   gamepadPrevStates: {},
-  gamepads: { },
+  gamepads: {},
   gamepadTab: false,
   gamepadHelpTab: false,
   suggestedCommands: [],
@@ -62,7 +62,7 @@ export const state = reactive({
   nameExistsResolve: null,
   nameExistsReject: null,
 
-  inventorySortValue: 'type',
+  inventorySortValue: 'name',  // Change because sorting by type does not work in some cases.
   inventoryOutput: {},
 
   scrolledBack: false,


### PR DESCRIPTION
Inventory sorting was not working properly by "name" because it was comparing the name along with all the ANSI color codes and the "L1" level, as well as the "3x" count and "o" socket markers. 

The sidebar inventory has all of the level, type, etc. set to 0 and "" so it can't sort by those. sortInventoryItems() will sort by level using the "L1" marker if level = 0. 

I don't know if this was the right place, but I added sortInventoryItems() to helpers.js. and changed  the individual inventory files to call it. "Name and level work in the sidebar, the trade window and the game menu inventory pane. The rest (type, weight, etc.) are hit-and-miss because the info is not always present.

A better solution might be to unify the way each of the inventory files store the info for the items, but I don't know enough about the project yet.

This is my first time using GitHub. Hopefully I did it correctly.
