### PR TITLE
chore: Onboarding basics

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the repository for the official Procedural Realms web client running at 
 
 ## Quickstart
 
-- Copy the contents of `.env.production` into `.env` to point the code to the production server.
+- Copy `.env.production` to `.env.local` to point the code to the production server.
 
 - Run the following commands to start the application:
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -54,7 +54,6 @@ export default [
       "comma-spacing": ["error", { "before": false, "after": true }],
       "func-call-spacing": ["error", "never"],
       "indent": ["error", 2],
-      "linebreak-style": ["error", "unix"],
       "new-parens": "error",
       "no-lonely-if": "error",
       "no-mixed-spaces-and-tabs": "error",


### PR DESCRIPTION
- Better instructions for how to use .env, as default .env is being pushed into the repository.
- Remove the LF ESLint rule, as it prevents Windows users from working on the code. It should instead be handled by `git config core.autocrlf = true` which is default on Windows.