### PR TITLE
fix: playerModalAs affecting mobile menu

### DIFF
--- a/src/components/mobile-menu/collapse-items/EquipmentCollapse.vue
+++ b/src/components/mobile-menu/collapse-items/EquipmentCollapse.vue
@@ -57,7 +57,7 @@ onMounted(() => {
   refreshRows()
 
   watchers.push(watch(
-    () => [state.playerModalAs, ...Object.values(getEquipment())].join('|'),
+    () => [...Object.values(getEquipment())].join('|'),
     () => {
       refreshRows()
     }
@@ -69,9 +69,6 @@ onBeforeUnmount(() => {
 })
 
 function getEquipment () {
-  if (state.playerModalAs && state.gameState.charmies[state.playerModalAs]) {
-    return state.gameState.charmies[state.playerModalAs].equipment
-  }
   return state.gameState.equipment
 }
 

--- a/src/components/modals/PlayerModal.vue
+++ b/src/components/modals/PlayerModal.vue
@@ -76,6 +76,7 @@ function onModalOpened () {
 
 function onModalClosed () {
   state.gamepadTab = currentPane.value
+  state.playerModalAs = ''
   watchers.forEach(unwatch => unwatch())
   watchers = []
 


### PR DESCRIPTION
- Resets `playerModalAs` when PlayerModal is closed.
- Removed connection between MobileMenu equipment pane and playerModalAs (it was the only pane that had this connection).