### PR TITLE
feat: Battle tweaks for ranged

### DIFF
--- a/src/components/battle/BattleField.vue
+++ b/src/components/battle/BattleField.vue
@@ -8,7 +8,8 @@
     >
       <div
         class="battlefield-position bold-red"
-      >{{ position }}</div>
+        v-html-safe="getPositionLabel(position)"
+      ></div>
 
       <div class="battlefield-entity-container">
         <div
@@ -37,6 +38,14 @@ import { useWebSocket } from '@/composables/web_socket'
 const { range, ansiToHtml } = useHelpers()
 const { runCommand } = useWebSocket()
 
+function getPositionLabel(position) {
+  if (state.options.battleRelativePositions) {
+    let me = state.gameState.battle.participants[state.gameState.player.eid]
+    return position - me.position
+  }
+
+  return position
+}
 function getTag(participant) {
   let me = state.gameState.battle.participants[state.gameState.player.eid]
   if (me.eid === participant.eid) {
@@ -49,6 +58,7 @@ function isMyTarget(participant) {
   let me = state.gameState.battle.participants[state.gameState.player.eid]
   return me.targetEid === participant.eid
 }
+
 function getParticipants (position) {
   let participants = Object.values(state.gameState.battle.participants)
     .filter(p => p.position === position)

--- a/src/components/battle/BattleField.vue
+++ b/src/components/battle/BattleField.vue
@@ -12,10 +12,15 @@
 
       <div class="battlefield-entity-container">
         <div
-          v-for="tag in getBattleTags(position)"
+          v-for="participant in getParticipants(position)"
           class="battlefield-entity"
-          :key="tag"
-          v-html-safe="ansiToHtml(tag)"
+          :class="{
+    'acting': participant.isActing,
+    'my-target': isMyTarget(participant),
+  }"
+          :key="participant.tag"
+          @click="setTarget($event, participant.eid)"
+          v-html-safe="ansiToHtml(getTag(participant))"
         ></div>
       </div>
 
@@ -32,13 +37,29 @@ import { useWebSocket } from '@/composables/web_socket'
 const { range, ansiToHtml } = useHelpers()
 const { runCommand } = useWebSocket()
 
-function getBattleTags (position) {
-  let tags = Object.values(state.gameState.battle.participants)
-    .filter(p => p.position === position)
-    .map(p => p.tag)
+function getTag(participant) {
+  let me = state.gameState.battle.participants[state.gameState.player.eid]
+  if (me.eid === participant.eid) {
+    return "You"
+  }
+  return participant.tag
+}
 
-  tags.sort((a, b) => -a.localeCompare(b))
-  return tags
+function isMyTarget(participant) {
+  let me = state.gameState.battle.participants[state.gameState.player.eid]
+  return me.targetEid === participant.eid
+}
+function getParticipants (position) {
+  let participants = Object.values(state.gameState.battle.participants)
+    .filter(p => p.position === position)
+
+  participants.sort((a, b) => -(a.tag).localeCompare(b.tag))
+  return participants
+}
+
+function setTarget ($event, targetEid) {
+  $event.stopPropagation()
+  runCommand(`target eid:${targetEid}`)
 }
 
 function onPositionClick (position) {
@@ -98,6 +119,24 @@ function onPositionClick (position) {
       flex: 1;
       flex-wrap: wrap;
       justify-content: space-around;
+    }
+
+    .battlefield-entity {
+      padding: 0 2px;
+      border: 1px solid transparent;
+      border-bottom: none;
+      &.my-target {
+        background-color: rgba(240, 210, 52, 0.1);
+        border-color: rgba(240, 210, 52, 0.3);
+      }
+      //&.acting {
+      //  background-color: rgba(240, 210, 52, 0.2);
+      //}
+      &:hover {
+        background-color: rgba(52, 240, 210, 0.2);
+        border-color: rgba(52, 240, 210, 0.3);
+        cursor: pointer;
+      }
     }
   }
 }

--- a/src/components/battle/BattleTable.vue
+++ b/src/components/battle/BattleTable.vue
@@ -121,7 +121,7 @@
           </div>
         </div>
         <div class="right">
-          <div class="number">{{ participant.position - meParticipant.position || ''}}</div>
+          <div class="number">{{ Math.abs(participant.position - meParticipant.position) || ''}}</div>
         </div>
         <div class="right">
           <div class="number">{{ participant.movement || ''}}</div>

--- a/src/components/battle/BattleTable.vue
+++ b/src/components/battle/BattleTable.vue
@@ -7,12 +7,48 @@
       <div class="participants-header">
         <div class="header-cell"></div>
         <div class="header-cell"></div>
-        <div class="header-cell target">TG</div>
-        <div class="header-cell right">MV</div>
-        <div class="header-cell right">HP</div>
-        <div class="header-cell right">EN</div>
-        <div class="header-cell right">ST</div>
-        <div class="header-cell right">Act</div>
+        <div class="header-cell target">
+          <NPopover trigger="hover" placement="top-start" :keep-alive-on-hover="false">
+            <template #trigger>TG</template>
+            <div class="tooltip">Target</div>
+          </NPopover>
+        </div>
+        <div class="header-cell right">
+          <NPopover trigger="hover" placement="top-start" :keep-alive-on-hover="false">
+            <template #trigger>DS</template>
+            <div class="tooltip">Distance</div>
+          </NPopover>
+        </div>
+        <div class="header-cell right">
+          <NPopover trigger="hover" placement="top-start" :keep-alive-on-hover="false">
+            <template #trigger>MV</template>
+            <div class="tooltip">Available Moves</div>
+          </NPopover>
+        </div>
+        <div class="header-cell right">
+          <NPopover trigger="hover" placement="top-start" :keep-alive-on-hover="false">
+            <template #trigger>HP</template>
+            <div class="tooltip">Health</div>
+          </NPopover>
+        </div>
+        <div class="header-cell right">
+          <NPopover trigger="hover" placement="top-start" :keep-alive-on-hover="false">
+            <template #trigger>EN</template>
+            <div class="tooltip">Energy</div>
+          </NPopover>
+        </div>
+        <div class="header-cell right">
+          <NPopover trigger="hover" placement="top-start" :keep-alive-on-hover="false">
+            <template #trigger>ST</template>
+            <div class="tooltip">Stamina</div>
+          </NPopover>
+        </div>
+        <div class="header-cell right">
+          <NPopover trigger="hover" placement="top-start" :keep-alive-on-hover="false">
+            <template #trigger>Act</template>
+            <div class="tooltip">Time to next action</div>
+          </NPopover>
+        </div>
       </div>
       <div
         :class="getParticipantClass(participant)"
@@ -85,6 +121,9 @@
           </div>
         </div>
         <div class="right">
+          <div class="number">{{ participant.position - meParticipant.position || ''}}</div>
+        </div>
+        <div class="right">
           <div class="number">{{ participant.movement || ''}}</div>
         </div>
         <div :class="getHpClass(participant)">
@@ -129,6 +168,8 @@ const { runCommand } = useWebSocket()
 
 const flashing = reactive({})
 const watchers = []
+
+const meParticipant = computed(() => state.gameState.battle.participants[state.gameState.player.eid])
 
 const participants = computed(() => {
   const { player, battle } = state.gameState
@@ -263,8 +304,20 @@ function getParticipantClass (participant) {
   let classes = ['participant']
   const { participants } = state.gameState.battle
   let me = participants[state.gameState.player.eid]
-  if (me.targetEid == participant.eid) {
+  if (me.targetEid === participant.eid) {
     classes.push('my-target')
+  }
+  if (isAlive(participant)) {
+    if (participant.side === 'good') {
+      classes.push('good')
+    } else if (participant.side === 'evil') {
+      classes.push('evil')
+    }
+  } else {
+    classes.push('dead')
+  }
+  if (participant.hidden) {
+    classes.push('hidden')
   }
   return classes
 }
@@ -429,6 +482,12 @@ onBeforeUnmount(() => {
         }
       }
 
+      &.good {
+        background-color: #001800;
+      }
+      &.evil {
+        background-color: #180000;
+      }
       &.my-target {
         background-color: rgba(240, 210, 52, 0.1);
       }

--- a/src/static/state.js
+++ b/src/static/state.js
@@ -377,6 +377,7 @@ export const configurableOptions = {
   'Battle': {
     'Battle Table Mode': 'battleTableMode',
     'Battle Always Expanded': 'battleAlwaysExpanded',
+    'Battle Relative Positions': 'battleRelativePositions',
     'Damage Animations': 'damageAnimations',
   },
 }
@@ -386,6 +387,7 @@ function resetOptions () {
     // general options
     battleAlwaysExpanded: true,
     battleTableMode: true,
+    battleRelativePositions: false,
     damageAnimations: true,
     battleExpanded: false,
     largeVitals: false,


### PR DESCRIPTION
Some legibility/convenience changes to improve my gameplay as a mage, who has to pick the right target to send piercing AoE spells onto.

Battlefield:
- Highlight targeted participant
- Make tags clickable for targeting
- Replace own tag with "You"
- "Relative positions" option to label positions with distance relative to you, instead of absolute index

Battle table:
- Background colors for good/evil
- Add DS (Distance) field; difference in positions to measure ranged skills with at a glance
- Add popovers for table headers

<img width="1667" height="423" alt="2026-06-11_18-24-31__chrome" src="https://github.com/user-attachments/assets/13cc7a7e-b917-4db0-93f3-0ee9ba3e7836" />
