### PR TITLE
feat: Open help links for skills

### DIFF
--- a/src/components/game-modal/SkillsPane.vue
+++ b/src/components/game-modal/SkillsPane.vue
@@ -26,7 +26,7 @@
           <div class="info" v-if="getCraftingSkills().length == 0">You haven't learned any crafting skills yet.</div>
           <div v-for="skill of getCraftingSkills()" :key="skill.name" class="skill">
             <div class="skill-info">
-              <div class="name">{{ skill.name }}</div>
+              <div class="name link" @click="openHelpPage(skill.name)">{{ skill.name }}</div>
               <div class="level">Level <span class="bold-white">{{ skill.level }}</span></div>
             </div>
             <NProgress type="line" status="default" :percentage="skill.tnl || 0" :border-radius="0" :height="8" :show-indicator="false"></NProgress>
@@ -43,7 +43,7 @@
           <div class="info" v-if="getCombatSkills().length == 0">You haven't learned any combat skills yet.</div>
           <div v-for="skill of getCombatSkills()" :key="skill.name" class="skill">
             <div class="skill-info">
-              <div class="name">{{ skill.name }}</div>
+              <div class="name link" @click="openHelpPage(skill.name)">{{ skill.name }}</div>
               <div class="level">Rank <span class="bold-white">{{ skill.rank }}</span></div>
             </div>
           </div>
@@ -59,7 +59,7 @@
           <div class="info" v-if="getArtisanSkills().length == 0">You haven't learned any artisan skills yet.</div>
           <div v-for="skill of getArtisanSkills()" :key="skill.name" class="skill">
             <div class="skill-info">
-              <div class="name">{{ skill.name }}</div>
+              <div class="name link" @click="openHelpPage(skill.name)">{{ skill.name }}</div>
               <div class="level">Rank <span class="bold-white">{{ skill.rank }}</span></div>
             </div>
           </div>
@@ -75,7 +75,9 @@ import { NGrid, NGi, NProgress } from 'naive-ui'
 
 import SelectPlayerModalAs from './SelectPlayerModalAs.vue'
 import { state } from '@/static/state'
+import { useWebSocket } from "@/composables/web_socket.js"
 
+const { runCommand } = useWebSocket()
 const props = defineProps(['miniOutputEnabled'])
 const { miniOutputEnabled } = toRefs(props)
 
@@ -93,6 +95,10 @@ function skills () {
   }
 
   return state.gameState.skills || {}
+}
+
+function openHelpPage (name) {
+  runCommand(`help ${name}`)
 }
 
 function getWeaponSkills () {
@@ -171,6 +177,17 @@ function getScrollContainerClass () {
       .skill {
         width: 350px;
         padding: 0 20px 5px 20px;
+
+        .name {
+          &.link {
+              cursor: pointer;
+              &:hover {
+                text-decoration: underline;
+                color: #f9f1a5;
+              }
+          }
+        }
+
         .skill-info {
           display: flex;
           justify-content: space-between;

--- a/src/components/mobile-menu/collapse-items/SkillsCollapse.vue
+++ b/src/components/mobile-menu/collapse-items/SkillsCollapse.vue
@@ -4,7 +4,7 @@
       <div class="skill-type bold-red">Weapon Skills</div>
       <div class="skill" v-for="skill in getSortedSkills('weapon')" :key="skill.name">
         <div class="skill-header">
-          <div>{{ skill.name }}</div>
+          <div class="name">{{ skill.name }}</div>
           <div>Level {{ skill.level }}</div>
         </div>
         <NProgress type="line" status="default" :percentage="skill.tnl" indicator-placement="inside">
@@ -17,7 +17,7 @@
       </div>
       <div class="skill" v-for="skill in getSortedSkills('crafting')" :key="skill.name">
         <div class="skill-header">
-          <div>{{ skill.name }}</div>
+          <div class="name link" @click="openHelpPage(skill.name)">{{ skill.name }}</div>
           <div>Level {{ skill.level }}</div>
         </div>
         <NProgress type="line" status="default" :percentage="skill.tnl" indicator-placement="inside">
@@ -30,7 +30,7 @@
       </div>
       <div class="skill" v-for="skill in getSortedSkills('combat')" :key="skill.name">
         <div class="skill-header">
-          <div>{{ skill.name }}</div>
+          <div class="name link" @click="openHelpPage(skill.name)">{{ skill.name }}</div>
           <div>Rank {{ skill.rank }}</div>
         </div>
       </div>
@@ -41,7 +41,7 @@
       </div>
       <div class="skill" v-for="skill in getSortedSkills('artisan')" :key="skill.name">
         <div class="skill-header">
-          <div>{{ skill.name }}</div>
+          <div class="name link" @click="openHelpPage(skill.name)">{{ skill.name }}</div>
           <div>Rank {{ skill.rank }}</div>
         </div>
       </div>
@@ -53,10 +53,16 @@
 import { defineProps, toRefs } from 'vue'
 
 import { NCollapseItem, NProgress } from 'naive-ui'
+import { useWebSocket } from "@/composables/web_socket.js"
 
+const { runCommand } = useWebSocket()
 const props = defineProps(['character', 'skills', 'isPlayer'])
 
 const { character, skills, isPlayer } = toRefs(props)
+
+function openHelpPage (name) {
+  runCommand(`help ${name}`)
+}
 
 function getSortedSkills (type) {
   const filtered = skills.value
@@ -112,10 +118,14 @@ function getSortedSkills (type) {
       justify-content: space-between;
     }
 
-    .expand-link {
-      color: #fff;
-      text-decoration: underline;
-      cursor: pointer;
+    .name {
+      &.link {
+        cursor: pointer;
+        &:hover {
+          text-decoration: underline;
+          color: #f9f1a5;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Turns the names of crafting, combat and artisan skills in the MobileMenu and GameModal into clickable links that will open a help page.

<img width="883" height="857" alt="2026-06-11_19-50-56__chrome" src="https://github.com/user-attachments/assets/1c39934c-de69-4d08-8a25-46ce55820e81" />